### PR TITLE
Release 0.5.0

### DIFF
--- a/Client/RAID-REVIEW.csproj
+++ b/Client/RAID-REVIEW.csproj
@@ -2,12 +2,12 @@
 
 	<PropertyGroup>
 		<TargetFramework>net472</TargetFramework>
-		<AssemblyName>RAID_REVIEW__0.4.0</AssemblyName>
+		<AssemblyName>RAID_REVIEW</AssemblyName>
 		<AssemblyTitle>RAID_REVIEW</AssemblyTitle>
 		<AssemblyDescription>A post raid review tool for SPT</AssemblyDescription>
 		<AssemblyCompany>EkkyLLC</AssemblyCompany>
 		<AssemblyProduct>RAID_REVIEW</AssemblyProduct>
-		<AssemblyVersion>0.4.0</AssemblyVersion>
+		<AssemblyVersion>0.5.0</AssemblyVersion>
 		<Copyright>2024 © Ekky</Copyright>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<OutputPath>C:\Games\SPT-4.0\BepInEx\plugins\</OutputPath>

--- a/Client/integrations/Integrations.cs
+++ b/Client/integrations/Integrations.cs
@@ -13,6 +13,26 @@ namespace RAID_REVIEW {
                     RAID_REVIEW.SOLARINT_SAIN__DETECTED = true;
                     RAID_REVIEW.RAID_REVIEW__DETECTED_MODS.Add("SAIN");
                 }
+                if (RAID_REVIEW.DetectMod("de.salco.themercenary"))
+                {
+                    LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: Found 'THE MERCENARY'.");
+                    RAID_REVIEW.RAID_REVIEW__DETECTED_MODS.Add("THE_MERCENARY");
+                }
+                if (RAID_REVIEW.DetectMod("com.ruafcomehome.tacticaltoaster"))
+                {
+                    LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: Found 'RUAF Come Home'.");
+                    RAID_REVIEW.RAID_REVIEW__DETECTED_MODS.Add("RUAF_COME_HOME");
+                }
+                if (RAID_REVIEW.DetectMod("com.untargh.tacticaltoaster"))
+                {
+                    LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: Found 'UNTAR Go Home'.");
+                    RAID_REVIEW.RAID_REVIEW__DETECTED_MODS.Add("UNTAR_GO_HOME");
+                }
+                if (RAID_REVIEW.DetectMod("com.blackdiv.tacticaltoaster"))
+                {
+                    LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: Found 'Black Division'.");
+                    RAID_REVIEW.RAID_REVIEW__DETECTED_MODS.Add("BLACK_DIVISION");
+                }
                 LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: Finished Searching For Supported Mods");
             }
             LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: RAID Settings Loaded");

--- a/Client/integrations/SAIN.cs
+++ b/Client/integrations/SAIN.cs
@@ -121,7 +121,16 @@ namespace RAID_REVIEW
 
                                 if (!isPMC)
                                 {
-                                    trackingPlayer.type = getBotType(info, profile);
+                                    var sainType = getBotType(info, profile);
+                                    // Only update if current type is generic or SAIN provides a specific (non-scav) type.
+                                    // Custom faction mods register bots that SAIN sees as "assault" internally,
+                                    // but mod.cs already identified them correctly via player.Profile.Info.Settings.Role.
+                                    bool currentIsGeneric = trackingPlayer.type == "BOT" || trackingPlayer.type == "UNKNOWN" || trackingPlayer.type == "SCAV|SCAV";
+                                    bool sainIsGeneric = sainType == "SCAV|SCAV" || sainType == "SCAV GROUP|SCAV" || sainType == "CRAZY SCAV EVENT|SCAV" || sainType == "TAGGED AND CURSED SCAV|SCAV";
+                                    if (currentIsGeneric || !sainIsGeneric)
+                                    {
+                                        trackingPlayer.type = sainType;
+                                    }
                                 }
 
                                 RAID_REVIEW.trackingPlayers[trackingPlayer.profileId] = trackingPlayer;
@@ -292,11 +301,69 @@ namespace RAID_REVIEW
                         case "followerKolontaySecurity":
                             RR_WildSpawnType = "KOLONTAY SECURITY|FOLLOWER";
                             break;
+                        case "bossPartisan":
+                            RR_WildSpawnType = "PARTIZAN|BOSS";
+                            break;
                         case "shooterBTR":
                             RR_WildSpawnType = "BTR|OTHER";
                             break;
+
+                        // THE MERCENARY
+                        case "mercenary":
+                            RR_WildSpawnType = "MERCENARY|MERCENARY";
+                            break;
+
+                        // RUAF Come Home
+                        case "ruafRifleman":
+                            RR_WildSpawnType = "RUAF RIFLEMAN|RUAF";
+                            break;
+                        case "ruafRiflemanSenior":
+                            RR_WildSpawnType = "RUAF SENIOR RIFLEMAN|RUAF";
+                            break;
+                        case "ruafAutorifleman":
+                            RR_WildSpawnType = "RUAF AUTORIFLEMAN|RUAF";
+                            break;
+                        case "ruafGrenadier":
+                            RR_WildSpawnType = "RUAF GRENADIER|RUAF";
+                            break;
+                        case "ruafMarksman":
+                            RR_WildSpawnType = "RUAF MARKSMAN|RUAF";
+                            break;
+                        case "ruafMachinegunner":
+                            RR_WildSpawnType = "RUAF MACHINEGUNNER|RUAF";
+                            break;
+
+                        // UNTAR Go Home
+                        case "followeruntar":
+                            RR_WildSpawnType = "UNTAR GUARD|UNTAR";
+                            break;
+                        case "bossuntarlead":
+                            RR_WildSpawnType = "UNTAR SQUAD LEADER|UNTAR";
+                            break;
+                        case "followeruntarmarksman":
+                            RR_WildSpawnType = "UNTAR MARKSMAN|UNTAR";
+                            break;
+                        case "bossuntarofficer":
+                            RR_WildSpawnType = "UNTAR OFFICER|UNTAR";
+                            break;
+
+                        // Black Division
+                        case "blackDivLead":
+                            RR_WildSpawnType = "BLACK DIV LEAD|BLACKDIV";
+                            break;
+                        case "blackDivAssault":
+                            RR_WildSpawnType = "BLACK DIV ASSAULT|BLACKDIV";
+                            break;
+                        case "blackDivBreacher":
+                            RR_WildSpawnType = "BLACK DIV BREACHER|BLACKDIV";
+                            break;
+                        case "blackDivSupport":
+                            RR_WildSpawnType = "BLACK DIV SUPPORT|BLACKDIV";
+                            break;
+
                         default:
-                            RR_WildSpawnType = "UNKNOWN";
+                            // Graceful fallback for unknown custom faction mods
+                            RR_WildSpawnType = wildSpawnType.ToString().ToUpper() + "|FACTION_MOD";
                             break;
                     }
                 }
@@ -307,8 +374,8 @@ namespace RAID_REVIEW
                     RR_WildSpawnType = "PLAYER_SCAV|SCAV";
                 }
 
-                // If a boss hasn't already been found, but the 'IsBoss' flag is true, return a 'boss'
-                if (!RR_WildSpawnType.EndsWith("BOSS") && isBoss)
+                // If no specific type was identified, but the 'IsBoss' flag is true, return a 'boss'
+                if (RR_WildSpawnType == "UNKNOWN" && isBoss)
                 {
                     RR_WildSpawnType = "CUSTOM|BOSS";
                 }

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -21,7 +21,7 @@ using EFT.HealthSystem;
 
 namespace RAID_REVIEW
 {
-    [BepInPlugin("ekky.raidreview", "Raid Review", "0.4.0")]
+    [BepInPlugin("ekky.raidreview", "Raid Review", "0.5.0")]
     [BepInDependency("me.sol.sain", BepInDependency.DependencyFlags.SoftDependency)]
     public class RAID_REVIEW : BaseUnityPlugin
     {
@@ -139,6 +139,27 @@ namespace RAID_REVIEW
         void Awake()
         {
             Logger.LogInfo("RAID_REVIEW :::: INFO :::: Mod Loaded");
+
+            // Clean up legacy versioned DLLs (e.g. RAID_REVIEW__0.4.0.dll) from older releases
+            try
+            {
+                var dllPath = System.Reflection.Assembly.GetExecutingAssembly().Location;
+                var pluginDir = System.IO.Path.GetDirectoryName(dllPath);
+                Logger.LogInfo($"RAID_REVIEW :::: INFO :::: Plugin directory: {pluginDir}");
+                if (pluginDir != null)
+                {
+                    foreach (var old in System.IO.Directory.GetFiles(pluginDir, "RAID_REVIEW*.dll"))
+                    {
+                        if (string.Equals(old, dllPath, System.StringComparison.OrdinalIgnoreCase)) continue;
+                        Logger.LogInfo($"RAID_REVIEW :::: INFO :::: Removing legacy DLL: {System.IO.Path.GetFileName(old)}");
+                        System.IO.File.Delete(old);
+                    }
+                }
+            }
+            catch (System.Exception ex)
+            {
+                Logger.LogWarning($"RAID_REVIEW :::: WARN :::: Failed to clean up legacy DLLs: {ex.Message}");
+            }
 
             // Configuration Bindings
             LaunchWebpageKey = Config.Bind("Main", "Open Webpage Keybind", new KeyboardShortcut(KeyCode.F5), "Keybind to open the web client.");

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -60,6 +60,75 @@ namespace RAID_REVIEW
         public static ConfigEntry<bool> ServerTLS;
         public static GameObject Hook;
 
+        /// <summary>
+        /// Maps a WildSpawnType to a Raid Review display string ("NAME|CATEGORY").
+        /// Used as a fallback when SAIN is not installed.
+        /// </summary>
+        public static string MapWildSpawnType(WildSpawnType role)
+        {
+            switch (role.ToString())
+            {
+                case "assault": return "SCAV|SCAV";
+                case "assaultGroup": return "SCAV GROUP|SCAV";
+                case "marksman": return "SCAV SNIPER|SNIPER";
+                case "cursedAssault": return "TAGGED AND CURSED SCAV|SCAV";
+                case "bossKnight": return "KNIGHT|GOON";
+                case "followerBigPipe": return "BIGPIPE|GOON";
+                case "followerBirdEye": return "BIRDEYE|GOON";
+                case "exUsec": return "ROGUE|FOLLOWER";
+                case "pmcBot": return "RAIDER|FOLLOWER";
+                case "arenaFighterEvent": return "BLOODHOUND|BLOODHOUND";
+                case "sectantPriest": return "CULTIST PRIEST|CULT";
+                case "sectantWarrior": return "CULTIST|CULT";
+                case "bossKilla": return "KILLA|BOSS";
+                case "bossBully": return "RASHALA|BOSS";
+                case "followerBully": return "RASHALA GUARD|FOLLOWER";
+                case "bossKojaniy": return "SHTURMAN|BOSS";
+                case "followerKojaniy": return "SHTURMAN GUARD|FOLLOWER";
+                case "bossTagilla": return "TAGILLA|BOSS";
+                case "followerTagilla": return "TAGILLA GUARD|FOLLOWER";
+                case "bossSanitar": return "SANITAR|BOSS";
+                case "followerSanitar": return "SANITAR GUARD|FOLLOWER";
+                case "bossGluhar": return "GLUHAR|BOSS";
+                case "followerGluharSnipe": return "GLUHAR GUARD SNIPE|FOLLOWER";
+                case "followerGluharScout": return "GLUHAR GUARD SCOUT|FOLLOWER";
+                case "followerGluharSecurity": return "GLUHAR GUARD SECURITY|FOLLOWER";
+                case "followerGluharAssault": return "GLUHAR GUARD ASSAULT|FOLLOWER";
+                case "bossZryachiy": return "ZRYACHIY|BOSS";
+                case "followerZryachiy": return "ZRYACHIY GUARD|FOLLOWER";
+                case "bossBoar": return "KABAN|BOSS";
+                case "followerBoar": return "KABAN GUARD|FOLLOWER";
+                case "bossBoarSniper": return "KABAN SNIPER|FOLLOWER";
+                case "bossKolontay": return "KOLONTAY|BOSS";
+                case "followerKolontayAssault": return "KOLONTAY ASSAULT|FOLLOWER";
+                case "followerKolontaySecurity": return "KOLONTAY SECURITY|FOLLOWER";
+                case "bossPartisan": return "PARTIZAN|BOSS";
+                case "shooterBTR": return "BTR|OTHER";
+                // PMC bots
+                case "pmcBEAR": return "PMC|BEAR";
+                case "pmcUSEC": return "PMC|USEC";
+                case "sptBear": return "PMC|BEAR";
+                case "sptUsec": return "PMC|USEC";
+                // Custom faction mods
+                case "mercenary": return "MERCENARY|MERCENARY";
+                case "ruafRifleman": return "RUAF RIFLEMAN|RUAF";
+                case "ruafRiflemanSenior": return "RUAF SENIOR RIFLEMAN|RUAF";
+                case "ruafAutorifleman": return "RUAF AUTORIFLEMAN|RUAF";
+                case "ruafGrenadier": return "RUAF GRENADIER|RUAF";
+                case "ruafMarksman": return "RUAF MARKSMAN|RUAF";
+                case "ruafMachinegunner": return "RUAF MACHINEGUNNER|RUAF";
+                case "followeruntar": return "UNTAR GUARD|UNTAR";
+                case "bossuntarlead": return "UNTAR SQUAD LEADER|UNTAR";
+                case "followeruntarmarksman": return "UNTAR MARKSMAN|UNTAR";
+                case "bossuntarofficer": return "UNTAR OFFICER|UNTAR";
+                case "blackDivLead": return "BLACK DIV LEAD|BLACKDIV";
+                case "blackDivAssault": return "BLACK DIV ASSAULT|BLACKDIV";
+                case "blackDivBreacher": return "BLACK DIV BREACHER|BLACKDIV";
+                case "blackDivSupport": return "BLACK DIV SUPPORT|BLACKDIV";
+                default: return role.ToString().ToUpper() + "|FACTION_MOD";
+            }
+        }
+
         // Other Mods
         public static bool MODS_SEARCHED = false;
         public static bool SOLARINT_SAIN__DETECTED { get; set; }
@@ -184,6 +253,20 @@ namespace RAID_REVIEW
                             else if (player.Side == EPlayerSide.Usec || player.Side == EPlayerSide.Bear)
                             {
                                 trackingPlayer.mod_SAIN_brain = "PMC";
+                            }
+
+                            // Read WildSpawnType directly for bot type detection
+                            // Must run for all AI (including Savage side) to detect bosses like Partizan
+                            if (player.IsAI)
+                            {
+                                try
+                                {
+                                    var role = player.Profile.Info.Settings.Role;
+                                    trackingPlayer.type = MapWildSpawnType(role);
+                                    // Override cyrillic names for known bosses
+                                    if (role.ToString() == "bossPartisan") trackingPlayer.name = "Partizan";
+                                }
+                                catch { }
                             }
 
                             trackingPlayers[trackingPlayer.profileId] = trackingPlayer;

--- a/Private/src/assets/botMapping.json
+++ b/Private/src/assets/botMapping.json
@@ -147,6 +147,10 @@
         "name": "Kolontay Security",
         "type": "FOLLOWER"
     },
+    "PARTIZAN|BOSS": {
+        "name": "Partizan",
+        "type": "BOSS"
+    },
     "BTR|OTHER": {
         "name": "BTR",
         "type": "OTHER"
@@ -154,6 +158,66 @@
     "CUSTOM|BOSS": {
         "name": "Custom Boss",
         "type": "BOSS"
+    },
+    "MERCENARY|MERCENARY": {
+        "name": "Mercenary",
+        "type": "MERCENARY"
+    },
+    "RUAF RIFLEMAN|RUAF": {
+        "name": "RUAF Rifleman",
+        "type": "RUAF"
+    },
+    "RUAF SENIOR RIFLEMAN|RUAF": {
+        "name": "RUAF Sr. Rifleman",
+        "type": "RUAF"
+    },
+    "RUAF AUTORIFLEMAN|RUAF": {
+        "name": "RUAF Autorifleman",
+        "type": "RUAF"
+    },
+    "RUAF GRENADIER|RUAF": {
+        "name": "RUAF Grenadier",
+        "type": "RUAF"
+    },
+    "RUAF MARKSMAN|RUAF": {
+        "name": "RUAF Marksman",
+        "type": "RUAF"
+    },
+    "RUAF MACHINEGUNNER|RUAF": {
+        "name": "RUAF Machinegunner",
+        "type": "RUAF"
+    },
+    "UNTAR GUARD|UNTAR": {
+        "name": "UNTAR Guard",
+        "type": "UNTAR"
+    },
+    "UNTAR SQUAD LEADER|UNTAR": {
+        "name": "UNTAR Squad Leader",
+        "type": "UNTAR"
+    },
+    "UNTAR MARKSMAN|UNTAR": {
+        "name": "UNTAR Marksman",
+        "type": "UNTAR"
+    },
+    "UNTAR OFFICER|UNTAR": {
+        "name": "UNTAR Officer",
+        "type": "UNTAR"
+    },
+    "BLACK DIV LEAD|BLACKDIV": {
+        "name": "Black Div Lead",
+        "type": "BLACKDIV"
+    },
+    "BLACK DIV ASSAULT|BLACKDIV": {
+        "name": "Black Div Assault",
+        "type": "BLACKDIV"
+    },
+    "BLACK DIV BREACHER|BLACKDIV": {
+        "name": "Black Div Breacher",
+        "type": "BLACKDIV"
+    },
+    "BLACK DIV SUPPORT|BLACKDIV": {
+        "name": "Black Div Support",
+        "type": "BLACKDIV"
     },
     "UNKNOWN": {
         "name": "",

--- a/Private/src/component/Map.css
+++ b/Private/src/component/Map.css
@@ -192,6 +192,20 @@
   border-radius: 50%;
 }
 
+/* Player Tooltip */
+.player-tooltip {
+  background: rgba(0, 0, 0, 0.85);
+  border: 1px solid rgba(154, 136, 102, 0.6);
+  color: #d4c9a8;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+.player-tooltip.leaflet-tooltip-top::before {
+  border-top-color: rgba(154, 136, 102, 0.6);
+}
+
 /* Icons */
 .killer-icon,
 .death-icon {

--- a/Private/src/component/Map.css
+++ b/Private/src/component/Map.css
@@ -169,6 +169,29 @@
   transform: translate(-55%);
 }
 
+/* Special Bot Markers */
+.special-bot-marker {
+  background: transparent !important;
+  border: none !important;
+}
+.bot-marker-dot {
+  width: 18px;
+  height: 18px;
+  border-radius: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  font-weight: bold;
+  color: #fff;
+  text-shadow: 0 0 3px rgba(0, 0, 0, 0.9);
+  border: 1.5px solid rgba(255, 255, 255, 0.6);
+  line-height: 1;
+}
+.bot-marker-dot.bot-marker-round {
+  border-radius: 50%;
+}
+
 /* Icons */
 .killer-icon,
 .death-icon {

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -58,6 +58,20 @@ function classifyPlayer(player: any): string {
     }
 }
 
+function getLegendIcon(player: any, color: string, pmcIdx?: number): JSX.Element {
+    const label = getMarkerLabel(player)
+    if (label) {
+        // Square marker with letter — matches map
+        return <span style={{ width: '18px', height: '18px', borderRadius: '2px', marginRight: '6px', background: color, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: '9px', fontWeight: 'bold', color: '#fff', textShadow: '0 0 2px rgba(0,0,0,0.9)', border: '1px solid rgba(255,255,255,0.6)', flexShrink: 0, lineHeight: 1 }}>{label}</span>
+    }
+    if (pmcIdx !== undefined) {
+        // Round marker with number — matches map
+        return <span style={{ width: '18px', height: '18px', borderRadius: '50%', marginRight: '6px', background: color, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: '9px', fontWeight: 'bold', color: '#fff', textShadow: '0 0 2px rgba(0,0,0,0.9)', border: '1px solid rgba(255,255,255,0.6)', flexShrink: 0, lineHeight: 1 }}>{pmcIdx}</span>
+    }
+    // Plain circle for scavs
+    return <span style={{ width: '10px', height: '10px', minWidth: '10px', minHeight: '10px', borderRadius: '50%', marginRight: '6px', background: color, border: '1px solid rgba(255,255,255,0.4)', flexShrink: 0, display: 'inline-block' }}></span>
+}
+
 const LEGEND_GROUPS = [
     { key: 'PMC', label: 'PMC' },
     { key: 'PLAYER_SCAV', label: 'Player Scav' },
@@ -107,7 +121,9 @@ function getMarkerLabel(player: any): string | null {
     return null
 }
 
-function createPlayerMarker(latlng: any, color: string, player: any, proportionalScale: number, opacity: number = 1, pmcIndex?: number): L.Layer {
+function createPlayerMarker(latlng: any, color: string, player: any, proportionalScale: number, opacity: number = 1, pmcIndex?: number, tooltipText?: string): L.Layer {
+    const displayName = tooltipText || getDisplayName(player)
+    const tooltipOpts: L.TooltipOptions = { direction: 'top', offset: [0, -10], className: 'player-tooltip' }
     const label = getMarkerLabel(player)
     if (label) {
         const icon = L.divIcon({
@@ -116,7 +132,7 @@ function createPlayerMarker(latlng: any, color: string, player: any, proportiona
             iconSize: [18, 18],
             iconAnchor: [9, 9],
         })
-        return L.marker(latlng, { icon, interactive: true })
+        return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, tooltipOpts)
     }
     // PMCs and player scavs get white border + number label
     if (pmcIndex !== undefined) {
@@ -126,10 +142,10 @@ function createPlayerMarker(latlng: any, color: string, player: any, proportiona
             iconSize: [18, 18],
             iconAnchor: [9, 9],
         })
-        return L.marker(latlng, { icon, interactive: true })
+        return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, tooltipOpts)
     }
     // Scavs: plain circle, no border
-    return L.circle(latlng, { radius: proportionalScale, color, fillOpacity: opacity, fillRule: 'nonzero', opacity })
+    return L.circle(latlng, { radius: proportionalScale, color, fillOpacity: opacity, fillRule: 'nonzero', opacity }).bindTooltip(displayName, tooltipOpts)
 }
 import '../modules/leaflet-heat.js'
 import './Map.css'
@@ -697,7 +713,8 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                             setFollowPlayer(playerId)
                             setFollowPlayerZoomed(false)
                         })
-                    const marker = createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, 1, pmcIndexMap[playerId])
+                    const tip = `${getDisplayName(player)} (${getPlayerDifficultyAndBrain(player)})`
+                    const marker = createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, 1, pmcIndexMap[playerId], tip)
                         .on('click', () => {
                             setFollowPlayer(playerId)
                             setFollowPlayerZoomed(false)
@@ -715,7 +732,8 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                             setFollowPlayerZoomed(false)
                         })
                     if (!isPlayerDead) {
-                        deferredMarkers.push({ layer: createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, focusedOpacityCircle, pmcIndexMap[playerId]), playerId, followAction: followPlayer === playerId })
+                        const tip = `${getDisplayName(player)} (${getPlayerDifficultyAndBrain(player)})`
+                        deferredMarkers.push({ layer: createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, focusedOpacityCircle, pmcIndexMap[playerId], tip), playerId, followAction: followPlayer === playerId })
                     }
                 }
 
@@ -729,7 +747,8 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                             setFollowPlayerZoomed(false)
                         })
                     if (!isPlayerDead) {
-                        deferredMarkers.push({ layer: createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, 1, pmcIndexMap[playerId]), playerId })
+                        const tip = `${getDisplayName(player)} (${getPlayerDifficultyAndBrain(player)})`
+                        deferredMarkers.push({ layer: createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, 1, pmcIndexMap[playerId], tip), playerId })
                         if (followPlayer === playerId) {
                             if (!followPlayerZoomed) {
                                 MAP.setZoom(3)
@@ -1208,10 +1227,10 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                                                                     }}
                                                                 >
                                                                     <div className={`flex flex-row items-center ${playerIsDead(player.profileId, timeEndLimit) ? 'line-through opacity-25' : ''}`}>
-                                                                        <span style={{ width: '8px', height: '8px', borderRadius: '50%', marginRight: '8px', background: getPlayerColor(player, originalIndex) }}></span>
+                                                                        {getLegendIcon(player, getPlayerColor(player, originalIndex), pmcIndexMap[player.profileId])}
                                                                         <div>
                                                                             <span className="capitalize">
-                                                                                {pmcIndexMap[player.profileId] ? `${pmcIndexMap[player.profileId]}. ` : ''}{intl(getDisplayName(player), intl_dir)} ({getPlayerDifficultyAndBrain(player)})
+                                                                                {intl(getDisplayName(player), intl_dir)} ({getPlayerDifficultyAndBrain(player)})
                                                                             </span>
                                                                         </div>
                                                                     </div>
@@ -1268,7 +1287,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                                                                     }}
                                                                 >
                                                                     <div className={`flex flex-row items-center ${playerIsDead(player.profileId, timeEndLimit) ? 'line-through opacity-25' : ''}`}>
-                                                                        <span style={{ width: '8px', height: '8px', borderRadius: '50%', marginRight: '8px', background: getPlayerColor(player, originalIndex) }}></span>
+                                                                        {getLegendIcon(player, getPlayerColor(player, originalIndex))}
                                                                         <div>
                                                                             <span className="capitalize">
                                                                                 {intl(getDisplayName(player), intl_dir)} ({getPlayerDifficultyAndBrain(player)})
@@ -1311,7 +1330,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                                                         }}
                                                     >
                                                         <div className={`flex flex-row items-center ${playerIsDead(player.profileId, timeEndLimit) ? 'line-through opacity-25' : ''}`}>
-                                                            <span style={{ width: '8px', height: '8px', borderRadius: '50%', marginRight: '8px', background: getPlayerColor(player, originalIndex) }}></span>
+                                                            {getLegendIcon(player, getPlayerColor(player, originalIndex))}
                                                             <div>
                                                                 <span className="capitalize">
                                                                     {intl(getDisplayName(player), intl_dir)} ({getPlayerDifficultyAndBrain(player)})
@@ -1364,7 +1383,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                                         >
                                             VIEW
                                         </a>
-                                        ] <strong>{e.profileNickname}</strong> killed <strong>{e.killedNickname}</strong> ({intl([e.weapon.replace('Name', 'ShortName')], intl_dir)} - {e.distance.toFixed(0)}m)
+                                        ] {(() => { const p = raidData.players.find(p => p.profileId === e.profileId); const idx = p ? raidData.players.indexOf(p) : 0; return p ? getLegendIcon(p, getPlayerColor(p, idx), pmcIndexMap[p.profileId]) : null })()}<strong>{e.profileNickname}</strong> killed {(() => { const p = raidData.players.find(p => p.profileId === e.killedId); const idx = p ? raidData.players.indexOf(p) : 0; return p ? getLegendIcon(p, getPlayerColor(p, idx), pmcIndexMap[p.profileId]) : null })()}<strong>{e.killedNickname}</strong> ({intl([e.weapon.replace('Name', 'ShortName')], intl_dir)} - {e.distance.toFixed(0)}m)
                                     </span>
                                 </div>
                             ))}

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -18,6 +18,119 @@ import { PlayerSlider } from './MapPlayerSlider.js';
 import BotMapping from '../assets/botMapping.json'
 
 import 'leaflet/dist/leaflet.css';
+
+const BOSS_NAME_OVERRIDES: Record<string, string> = {
+    'Партизан': 'Partizan',
+}
+
+function getDisplayName(player: any): string {
+    return BOSS_NAME_OVERRIDES[player?.name] || player?.name || 'Unknown'
+}
+
+function classifyPlayer(player: any): string {
+    if (!player) return 'SCAV'
+    const isPMC = player.team === 'Bear' || player.team === 'Usec'
+    const isHuman = player.type === 'HUMAN'
+    if (isPMC || isHuman) return 'PMC'
+
+    let botMapping = BotMapping[player.type]
+    if (player.name === 'Knight') botMapping = { type: 'GOON' }
+    if (!botMapping) botMapping = { type: 'UNKNOWN' }
+
+    switch (botMapping.type) {
+        case 'PLAYER_SCAV': return 'PLAYER_SCAV'
+        case 'BOSS': return 'BOSS'
+        case 'GOON': return 'GOON'
+        case 'FOLLOWER': return 'FOLLOWER'
+        case 'RAIDER':
+        case 'ROGUE':
+        case 'CULT':
+        case 'BLOODHOUND':
+        case 'SNIPER': return 'SPECIAL'
+        case 'MERCENARY':
+        case 'RUAF':
+        case 'UNTAR':
+        case 'BLACKDIV': return 'FACTION'
+        case 'SCAV':
+        default:
+            if (player.type === 'PLAYER' && player.team === 'Savage') return 'SCAV'
+            return 'SCAV'
+    }
+}
+
+const LEGEND_GROUPS = [
+    { key: 'PMC', label: 'PMC' },
+    { key: 'PLAYER_SCAV', label: 'Player Scav' },
+    { key: 'BOSS', label: 'Boss' },
+    { key: 'GOON', label: 'Goons' },
+    { key: 'FOLLOWER', label: 'Followers' },
+    { key: 'SPECIAL', label: 'Special' },
+    { key: 'FACTION', label: 'Faction' },
+    { key: 'SCAV', label: 'Scav' },
+] as const
+
+function getMarkerLabel(player: any): string | null {
+    const type = (player?.type || '').toUpperCase()
+
+    // Bosses
+    if (type.includes('KILLA')) return 'Ki'
+    if (type.includes('RASHALA')) return 'Ra'
+    if (type.includes('SHTURMAN')) return 'Sh'
+    if (type.includes('TAGILLA')) return 'Ta'
+    if (type.includes('SANITAR')) return 'Sa'
+    if (type.includes('GLUHAR')) return 'Gl'
+    if (type.includes('ZRYACHIY')) return 'Zr'
+    if (type.includes('KABAN')) return 'Kb'
+    if (type.includes('KOLONTAY')) return 'Ko'
+    if (type.includes('PARTIZAN')) return 'P'
+
+    // Goons
+    if (type.includes('KNIGHT')) return 'Kn'
+    if (type.includes('BIGPIPE')) return 'BP'
+    if (type.includes('BIRDEYE')) return 'BE'
+
+    // Factions
+    if (type.includes('MERCENARY')) return 'M'
+    if (type.includes('RUAF')) return 'R'
+    if (type.includes('UNTAR')) return 'U'
+    if (type.includes('BLACK DIV')) return 'BD'
+
+    // Special types
+    if (type.includes('RAIDER')) return 'Rd'
+    if (type.includes('ROGUE')) return 'Rg'
+    if (type.includes('CULTIST PRIEST')) return 'CP'
+    if (type.includes('CULTIST')) return 'Cu'
+    if (type.includes('BLOODHOUND')) return 'Bh'
+    if (type.includes('BTR')) return 'BT'
+    if (type.includes('SNIPER')) return 'Sn'
+
+    return null
+}
+
+function createPlayerMarker(latlng: any, color: string, player: any, proportionalScale: number, opacity: number = 1, pmcIndex?: number): L.Layer {
+    const label = getMarkerLabel(player)
+    if (label) {
+        const icon = L.divIcon({
+            className: 'special-bot-marker',
+            html: `<div class="bot-marker-dot" style="background-color: ${color}; opacity: ${opacity};">${label}</div>`,
+            iconSize: [18, 18],
+            iconAnchor: [9, 9],
+        })
+        return L.marker(latlng, { icon, interactive: true })
+    }
+    // PMCs and player scavs get white border + number label
+    if (pmcIndex !== undefined) {
+        const icon = L.divIcon({
+            className: 'special-bot-marker',
+            html: `<div class="bot-marker-dot bot-marker-round" style="background-color: ${color}; opacity: ${opacity};">${pmcIndex}</div>`,
+            iconSize: [18, 18],
+            iconAnchor: [9, 9],
+        })
+        return L.marker(latlng, { icon, interactive: true })
+    }
+    // Scavs: plain circle, no border
+    return L.circle(latlng, { radius: proportionalScale, color, fillOpacity: opacity, fillRule: 'nonzero', opacity })
+}
 import '../modules/leaflet-heat.js'
 import './Map.css'
 
@@ -180,7 +293,8 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
     const [followPlayerZoomed, setFollowPlayerZoomed] = useState(false)
     const [calculatedPlayerInfo, setCalculatedPlayerInfo] = useState({})
     const [calculatedLayerInfo, setCalculatedLayerInfo] = useState({})
-    const [playerFocus, setPlayerFocus] = useState(null)
+    const [playerFocus, setPlayerFocus] = useState<string | null>(null)
+    const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set(['SCAV']))
     const [proportionalScale, setProportionalScale] = useState(0)
     const [MAP, SET_MAP] = useState(null)
     const [mapHeight, setMapHeight] = useState(600)
@@ -202,6 +316,23 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
 
     // Events
     const [events, setEvents] = useState([])
+
+    // Pre-compute PMC index within each team group (for numbered markers in legend + map)
+    const pmcIndexMap = useMemo(() => {
+        const map: Record<string, number> = {}
+        const groupCounters: Record<number, number> = {}
+        for (const p of raidData.players) {
+            const isPMC = p.team === 'Usec' || p.team === 'Bear'
+            const isHuman = p.type === 'HUMAN'
+            if (isPMC || isHuman) {
+                const group = p.group ?? 0
+                if (groupCounters[group] === undefined) groupCounters[group] = 0
+                groupCounters[group]++
+                map[p.profileId] = groupCounters[group]
+            }
+        }
+        return map
+    }, [raidData.players])
 
     const focusItem = useRef(searchParams.get('q') ? searchParams.get('q').split(',') : [])
     const mapViewRef = useRef({})
@@ -512,6 +643,9 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
 
         clearMap(MAP, { start: timeStartLimit, end: timeEndLimit })
 
+        // Two-pass rendering: polylines first, then markers (so dots are always on top)
+        const deferredMarkers: { layer: L.Layer, playerId: string, followAction?: boolean }[] = []
+
         const playerPositionKeys = Object.keys(positions)
         for (let i = 0; i < playerPositionKeys.length; i++) {
             if (MAP === undefined) continue
@@ -541,7 +675,6 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
             }
 
             const index = calculatedPlayerInfo[playerId]?.index || raidData.players.findIndex((p) => p.profileId === playerId)
-            // if (!index) continue;
             const player = calculatedPlayerInfo[playerId]?.player || raidData.players[index]
             const pickedColor = calculatedPlayerInfo[playerId]?.pickedColor || getPlayerColor(player, index)
             if (calculatedPlayerInfo[playerId] === undefined) {
@@ -555,7 +688,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                 let endOfLine = cleanPositions[cleanPositions.length - 1]
 
                 // Focused Player
-                if (playerFocus !== null && playerFocus === i) {
+                if (playerFocus !== null && playerFocus === playerId) {
 
                     if (!MAP) return
                     L.polyline(cleanPositions, { color: pickedColor, weight: 4, opacity: 1 })
@@ -564,12 +697,12 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                             setFollowPlayer(playerId)
                             setFollowPlayerZoomed(false)
                         })
-                    L.circle(endOfLine, { radius: proportionalScale, color: pickedColor, fillOpacity: 1, fillRule: 'nonzero' })
-                        .addTo(MAP)
+                    const marker = createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, 1, pmcIndexMap[playerId])
                         .on('click', () => {
                             setFollowPlayer(playerId)
                             setFollowPlayerZoomed(false)
                         })
+                    deferredMarkers.push({ layer: marker, playerId })
                 } else {
                     let focusedOpacityPolyLine = preserveHistory ? 0.1 : isPlayerDead ? 0 : 0.1
                     let focusedOpacityCircle = isPlayerDead ? 0 : 0.1
@@ -582,10 +715,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                             setFollowPlayerZoomed(false)
                         })
                     if (!isPlayerDead) {
-                        L.circle(endOfLine, { radius: proportionalScale, color: pickedColor, opacity: focusedOpacityCircle, fillOpacity: 1, fillRule: 'nonzero' }).addTo(MAP)
-                        if (followPlayer === playerId) {
-                            MAP.panTo(endOfLine, 4)
-                        }
+                        deferredMarkers.push({ layer: createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, focusedOpacityCircle, pmcIndexMap[playerId]), playerId, followAction: followPlayer === playerId })
                     }
                 }
 
@@ -599,10 +729,9 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                             setFollowPlayerZoomed(false)
                         })
                     if (!isPlayerDead) {
-                        L.circle(endOfLine, { radius: proportionalScale, color: pickedColor, fillOpacity: 1, fillRule: 'nonzero' }).addTo(MAP)
+                        deferredMarkers.push({ layer: createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, 1, pmcIndexMap[playerId]), playerId })
                         if (followPlayer === playerId) {
                             if (!followPlayerZoomed) {
-                                // This is here to make sure the user can adjust zoom as a player is followed
                                 MAP.setZoom(3)
                                 setFollowPlayerZoomed(true)
                             }
@@ -610,6 +739,14 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                         }
                     }
                 }
+            }
+        }
+
+        // Second pass: add all markers on top of polylines
+        for (const { layer, playerId, followAction } of deferredMarkers) {
+            layer.addTo(MAP)
+            if (followAction) {
+                MAP.panTo((layer as any).getLatLng?.() || (layer as any)._latlng, 4)
             }
         }
 
@@ -623,7 +760,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
             setTimeEndLimit(times[times.length - 1])
             setTimeCurrentIndex(times.length - 1)
         }
-    }, [mapIsReady, mapViewRef, timeEndLimit, timeStartLimit, timeCurrentIndex, MAP, preserveHistory, events, hideEvents, hidePlayers, followPlayer, playerFocus])
+    }, [mapIsReady, mapViewRef, timeEndLimit, timeStartLimit, timeCurrentIndex, MAP, preserveHistory, events, hideEvents, hidePlayers, followPlayer, playerFocus, pmcIndexMap])
 
     // Slider Time Update
     useEffect(() => {
@@ -811,8 +948,9 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
         for (const key in m._layers) {
             const layer = m._layers[key];
         
-            // Remove polylines without eventType or not being ballisticsLine, and circles
-            if ((layer instanceof L.Polyline && (!layer.eventType || layer.eventType !== 'ballisticsLine')) || layer instanceof L.Circle) {
+            // Remove polylines without eventType or not being ballisticsLine, circles, and special bot markers
+            const isSpecialBotMarker = layer instanceof L.Marker && layer.options?.icon?.options?.className === 'special-bot-marker';
+            if ((layer instanceof L.Polyline && (!layer.eventType || layer.eventType !== 'ballisticsLine')) || layer instanceof L.Circle || isSpecialBotMarker) {
                 m.removeLayer(layer);
                 continue;
             }
@@ -955,9 +1093,17 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                 return '#6f00ff' // Dark Purple - Cultist
             case 'OTHER':
                 return '#00eeff' // Other - Cyan
+            case 'MERCENARY':
+                return '#FFD700' // Gold - Mercenary
+            case 'RUAF':
+                return '#4A90D9' // Steel Blue - RUAF
+            case 'UNTAR':
+                return '#00BFFF' // Light Blue - UNTAR
+            case 'BLACKDIV':
+                return '#555555' // Dark Grey - Black Division
             default:
                 if (player.type === 'PLAYER' && player.team === 'Savage') return '#33FF57' // Green - Scav
-                else return colors[index % colors.length] // PMC
+                else return colors[(player.group ?? index) % colors.length] // PMC - color by team group
         }
     }
 
@@ -998,32 +1144,189 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                 <aside className="sidebar border border-eft mr-3 p-3 overflow-x-auto">
                     <div className="playerfeed text-eft">
                         <strong>Legend</strong>
-                        <ul>
-                            {raidData.players
-                                .filter((p) => p.spawnTime < timeEndLimit)
-                                .map((player, index) => (
-                                    <li
-                                        className="flex items-center justify-between player-legend-item px-2"
-                                        key={player.profileId}
-                                        onMouseEnter={() => setPlayerFocus(index)}
-                                        onMouseLeave={() => setPlayerFocus(null)}
-                                        onClick={() => {
-                                            setFollowPlayer(followPlayer === player.profileId ? null : player.profileId)
-                                            setFollowPlayerZoomed(false)
-                                        }}
-                                    >
-                                        <div className={`flex flex-row items-center ${playerIsDead(player.profileId, timeEndLimit) ? 'line-through opacity-25' : ''}`}>
-                                            <span style={{ width: '8px', height: '8px', borderRadius: '50%', marginRight: '8px', background: getPlayerColor(player, index) }}></span>
-                                            <div>
-                                                <span className="capitalize">
-                                                    {intl(player.name, intl_dir)} ({getPlayerDifficultyAndBrain(player)})
-                                                </span>
+                        {(() => {
+                            const visiblePlayers = raidData.players.filter((p) => p.spawnTime < timeEndLimit)
+                            const grouped: Record<string, { player: any, originalIndex: number }[]> = {}
+                            visiblePlayers.forEach((player) => {
+                                const cat = classifyPlayer(player)
+                                const origIdx = raidData.players.indexOf(player)
+                                if (!grouped[cat]) grouped[cat] = []
+                                grouped[cat].push({ player, originalIndex: origIdx })
+                            })
+
+                            const toggleGroup = (key: string) => {
+                                setCollapsedGroups(prev => {
+                                    const next = new Set(prev)
+                                    if (next.has(key)) next.delete(key)
+                                    else next.add(key)
+                                    return next
+                                })
+                            }
+
+                            return LEGEND_GROUPS.filter(g => grouped[g.key]?.length > 0).map(group => {
+                                const items = grouped[group.key]
+                                const isCollapsed = collapsedGroups.has(group.key)
+
+                                // PMC sub-grouping by team
+                                if (group.key === 'PMC') {
+                                    const teams: Record<number, { player: any, originalIndex: number }[]> = {}
+                                    items.forEach(item => {
+                                        const g = item.player.group ?? 0
+                                        if (!teams[g]) teams[g] = []
+                                        teams[g].push(item)
+                                    })
+                                    const teamKeys = Object.keys(teams).map(Number).sort((a, b) => a - b)
+
+                                    return (
+                                        <div key={group.key}>
+                                            <div
+                                                className="flex items-center cursor-pointer py-1 mt-2"
+                                                style={{ borderBottom: '1px solid rgba(154, 136, 102, 0.3)', fontSize: '12px' }}
+                                                onClick={() => toggleGroup(group.key)}
+                                            >
+                                                <span style={{ marginRight: '4px', fontSize: '8px' }}>{isCollapsed ? '\u25B6' : '\u25BC'}</span>
+                                                <span>{group.label} ({items.length})</span>
                                             </div>
+                                            {!isCollapsed && teamKeys.map(teamKey => {
+                                                const teamPlayers = teams[teamKey]
+                                                const teamColor = getPlayerColor(teamPlayers[0].player, teamPlayers[0].originalIndex)
+                                                return (
+                                                    <div key={teamKey}>
+                                                        <div className="text-xs pl-2 pt-1" style={{ color: teamColor, opacity: 0.8 }}>
+                                                            Team {teamKey}
+                                                        </div>
+                                                        <ul>
+                                                            {teamPlayers.map(({ player, originalIndex }) => (
+                                                                <li
+                                                                    className="flex items-center justify-between player-legend-item px-2"
+                                                                    key={player.profileId}
+                                                                    onMouseEnter={() => setPlayerFocus(player.profileId)}
+                                                                    onMouseLeave={() => setPlayerFocus(null)}
+                                                                    onClick={() => {
+                                                                        setFollowPlayer(followPlayer === player.profileId ? null : player.profileId)
+                                                                        setFollowPlayerZoomed(false)
+                                                                    }}
+                                                                >
+                                                                    <div className={`flex flex-row items-center ${playerIsDead(player.profileId, timeEndLimit) ? 'line-through opacity-25' : ''}`}>
+                                                                        <span style={{ width: '8px', height: '8px', borderRadius: '50%', marginRight: '8px', background: getPlayerColor(player, originalIndex) }}></span>
+                                                                        <div>
+                                                                            <span className="capitalize">
+                                                                                {pmcIndexMap[player.profileId] ? `${pmcIndexMap[player.profileId]}. ` : ''}{intl(getDisplayName(player), intl_dir)} ({getPlayerDifficultyAndBrain(player)})
+                                                                            </span>
+                                                                        </div>
+                                                                    </div>
+                                                                    {followPlayer === player.profileId ? <span className="text-xs">[FOLLOWING]</span> : ''}
+                                                                </li>
+                                                            ))}
+                                                        </ul>
+                                                    </div>
+                                                )
+                                            })}
                                         </div>
-                                        {followPlayer === player.profileId ? <span className="text-xs">[FOLLOWING]</span> : ''}
-                                    </li>
-                                ))}
-                        </ul>
+                                    )
+                                }
+
+                                // Faction sub-grouping by faction type
+                                if (group.key === 'FACTION') {
+                                    const FACTION_LABELS: Record<string, string> = { MERCENARY: 'Mercenary', RUAF: 'RUAF', UNTAR: 'UNTAR', BLACKDIV: 'Black Div' }
+                                    const factions: Record<string, { player: any, originalIndex: number }[]> = {}
+                                    items.forEach(item => {
+                                        const fType = BotMapping[item.player.type]?.type || 'UNKNOWN'
+                                        if (!factions[fType]) factions[fType] = []
+                                        factions[fType].push(item)
+                                    })
+                                    const factionKeys = Object.keys(factions)
+
+                                    return (
+                                        <div key={group.key}>
+                                            <div
+                                                className="flex items-center cursor-pointer py-1 mt-2"
+                                                style={{ borderBottom: '1px solid rgba(154, 136, 102, 0.3)', fontSize: '12px' }}
+                                                onClick={() => toggleGroup(group.key)}
+                                            >
+                                                <span style={{ marginRight: '4px', fontSize: '8px' }}>{isCollapsed ? '\u25B6' : '\u25BC'}</span>
+                                                <span>{group.label} ({items.length})</span>
+                                            </div>
+                                            {!isCollapsed && factionKeys.map(fKey => {
+                                                const fPlayers = factions[fKey]
+                                                const fColor = getPlayerColor(fPlayers[0].player, fPlayers[0].originalIndex)
+                                                return (
+                                                    <div key={fKey}>
+                                                        <div className="text-xs pl-2 pt-1" style={{ color: fColor, opacity: 0.8 }}>
+                                                            {FACTION_LABELS[fKey] || fKey}
+                                                        </div>
+                                                        <ul>
+                                                            {fPlayers.map(({ player, originalIndex }) => (
+                                                                <li
+                                                                    className="flex items-center justify-between player-legend-item px-2"
+                                                                    key={player.profileId}
+                                                                    onMouseEnter={() => setPlayerFocus(player.profileId)}
+                                                                    onMouseLeave={() => setPlayerFocus(null)}
+                                                                    onClick={() => {
+                                                                        setFollowPlayer(followPlayer === player.profileId ? null : player.profileId)
+                                                                        setFollowPlayerZoomed(false)
+                                                                    }}
+                                                                >
+                                                                    <div className={`flex flex-row items-center ${playerIsDead(player.profileId, timeEndLimit) ? 'line-through opacity-25' : ''}`}>
+                                                                        <span style={{ width: '8px', height: '8px', borderRadius: '50%', marginRight: '8px', background: getPlayerColor(player, originalIndex) }}></span>
+                                                                        <div>
+                                                                            <span className="capitalize">
+                                                                                {intl(getDisplayName(player), intl_dir)} ({getPlayerDifficultyAndBrain(player)})
+                                                                            </span>
+                                                                        </div>
+                                                                    </div>
+                                                                    {followPlayer === player.profileId ? <span className="text-xs">[FOLLOWING]</span> : ''}
+                                                                </li>
+                                                            ))}
+                                                        </ul>
+                                                    </div>
+                                                )
+                                            })}
+                                        </div>
+                                    )
+                                }
+
+                                // Standard group
+                                return (
+                                    <div key={group.key}>
+                                        <div
+                                            className="flex items-center cursor-pointer py-1 mt-2"
+                                            style={{ borderBottom: '1px solid rgba(154, 136, 102, 0.3)', fontSize: '12px' }}
+                                            onClick={() => toggleGroup(group.key)}
+                                        >
+                                            <span style={{ marginRight: '4px', fontSize: '8px' }}>{isCollapsed ? '\u25B6' : '\u25BC'}</span>
+                                            <span>{group.label} ({items.length})</span>
+                                        </div>
+                                        {!isCollapsed && (
+                                            <ul>
+                                                {items.map(({ player, originalIndex }) => (
+                                                    <li
+                                                        className="flex items-center justify-between player-legend-item px-2"
+                                                        key={player.profileId}
+                                                        onMouseEnter={() => setPlayerFocus(player.profileId)}
+                                                        onMouseLeave={() => setPlayerFocus(null)}
+                                                        onClick={() => {
+                                                            setFollowPlayer(followPlayer === player.profileId ? null : player.profileId)
+                                                            setFollowPlayerZoomed(false)
+                                                        }}
+                                                    >
+                                                        <div className={`flex flex-row items-center ${playerIsDead(player.profileId, timeEndLimit) ? 'line-through opacity-25' : ''}`}>
+                                                            <span style={{ width: '8px', height: '8px', borderRadius: '50%', marginRight: '8px', background: getPlayerColor(player, originalIndex) }}></span>
+                                                            <div>
+                                                                <span className="capitalize">
+                                                                    {intl(getDisplayName(player), intl_dir)} ({getPlayerDifficultyAndBrain(player)})
+                                                                </span>
+                                                            </div>
+                                                        </div>
+                                                        {followPlayer === player.profileId ? <span className="text-xs">[FOLLOWING]</span> : ''}
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        )}
+                                    </div>
+                                )
+                            })
+                        })()}
                     </div>
                 </aside>
                 <div className="map-wrapper border border-eft map">

--- a/Private/src/pages/V2/RaidOverview.tsx
+++ b/Private/src/pages/V2/RaidOverview.tsx
@@ -12,6 +12,10 @@ import _ from "lodash";
 import { LOCATIONS } from "../../helpers/locations";
 import cyr_to_en from '../../assets/cyr_to_en.json';
 
+const BOSS_NAME_OVERRIDES: Record<string, string> = {
+    'Партизан': 'Partizan',
+}
+
 export default function RaidOverview() {
     const { raid, intl: intl_dir_ot } = useOutletContext() as { raid: TrackingRaidData, intl: { [key:string] : string } };
 
@@ -158,6 +162,14 @@ export default function RaidOverview() {
                   return "CULTIST"
               case 'BLOODHOUND':
                   return "BLOODHOUND"
+              case 'MERCENARY':
+                  return "MERCENARY"
+              case 'RUAF':
+                  return "RUAF"
+              case 'UNTAR':
+                  return "UNTAR"
+              case 'BLACKDIV':
+                  return "BLACK DIV"
               default:
                   if(player.team === "Savage") {
                     return ""
@@ -209,7 +221,7 @@ export default function RaidOverview() {
               <td className="text-right p-2 uppercase">{ p.team === 'Savage' ? 'Scav' : p.team }</td>
               <td className="text-center p-2 uppercase border-x border-eft">{ p.group }</td>
               <td className="text-center p-2 uppercase border-x border-eft">{ p.level }</td>
-              <td className="text-left p-2">{KIA ? '' : ' 💀 '}{ intl(p.name, intl_dir) }</td>
+              <td className="text-left p-2">{KIA ? '' : ' 💀 '}{ intl(BOSS_NAME_OVERRIDES[p.name] || p.name, intl_dir) }</td>
               <td className="text-right p-2 capitalize">{ raid.detectedMods?.match(/SAIN/gi) ? SAIN : '' }</td>
               <td className="text-center p-2 w-12 border-l border-eft">{ calcStats ? calcStats.get(p.profileId)?.kills || '-' : null  }</td>
               <td className={`text-center p-2 w-12 ${(calcStats && (calcStats.get(p.profileId)?.lootings || 0) < 0) ? 'text-red-400' : 'text-green-400'}`}>{ calcStats ? calcStats.get(p.profileId)?.lootings || '-'  : null }</td>

--- a/ServerMod/Database/DatabaseService.cs
+++ b/ServerMod/Database/DatabaseService.cs
@@ -124,6 +124,92 @@ public class DatabaseService : IDisposable
                     FOREIGN KEY (""raidId"") REFERENCES raid(""id"")
                 );
             "),
+            ("fix_foreign_keys", @"
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_raid_raidId ON raid(""raidId"");
+
+                CREATE TABLE player_new (
+                    ""id"" INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ""raidId"" TEXT NOT NULL,
+                    ""profileId"" TEXT NOT NULL,
+                    ""level"" INTEGER NOT NULL,
+                    ""team"" TEXT NOT NULL,
+                    ""name"" TEXT NOT NULL,
+                    ""group"" INTEGER NOT NULL,
+                    ""spawnTime"" INTEGER NOT NULL,
+                    ""type"" TEXT NOT NULL DEFAULT 'BOT',
+                    ""mod_SAIN_brain"" TEXT NOT NULL DEFAULT 'UNKNOWN',
+                    ""mod_SAIN_difficulty"" TEXT NOT NULL DEFAULT '',
+                    ""created_at"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (""raidId"") REFERENCES raid(""raidId"")
+                );
+                INSERT INTO player_new SELECT * FROM player;
+                DROP TABLE player;
+                ALTER TABLE player_new RENAME TO player;
+
+                CREATE TABLE kills_new (
+                    ""id"" INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ""raidId"" TEXT NOT NULL,
+                    ""profileId"" TEXT NOT NULL,
+                    ""time"" INTEGER NOT NULL,
+                    ""killedId"" TEXT NOT NULL,
+                    ""weapon"" TEXT NOT NULL,
+                    ""distance"" TEXT NOT NULL,
+                    ""bodyPart"" TEXT NOT NULL,
+                    ""positionKilled"" TEXT NOT NULL,
+                    ""positionKiller"" TEXT NOT NULL,
+                    ""created_at"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (""raidId"") REFERENCES raid(""raidId"")
+                );
+                INSERT INTO kills_new SELECT * FROM kills;
+                DROP TABLE kills;
+                ALTER TABLE kills_new RENAME TO kills;
+
+                CREATE TABLE looting_new (
+                    ""id"" INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ""raidId"" TEXT NOT NULL,
+                    ""profileId"" TEXT NOT NULL,
+                    ""time"" TEXT NOT NULL,
+                    ""qty"" TEXT NOT NULL,
+                    ""itemId"" TEXT NOT NULL,
+                    ""itemName"" TEXT NOT NULL,
+                    ""added"" TEXT NOT NULL,
+                    ""created_at"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (""raidId"") REFERENCES raid(""raidId"")
+                );
+                INSERT INTO looting_new SELECT * FROM looting;
+                DROP TABLE looting;
+                ALTER TABLE looting_new RENAME TO looting;
+
+                CREATE TABLE ballistic_new (
+                    ""id"" INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ""raidId"" TEXT NOT NULL,
+                    ""time"" INTEGER NOT NULL,
+                    ""profileId"" TEXT NOT NULL,
+                    ""weaponId"" TEXT NOT NULL,
+                    ""ammoId"" TEXT NOT NULL,
+                    ""hitPlayerId"" TEXT,
+                    ""source"" TEXT NOT NULL,
+                    ""target"" TEXT NOT NULL,
+                    ""created_at"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (""raidId"") REFERENCES raid(""raidId"")
+                );
+                INSERT INTO ballistic_new SELECT * FROM ballistic;
+                DROP TABLE ballistic;
+                ALTER TABLE ballistic_new RENAME TO ballistic;
+
+                CREATE TABLE player_status_new (
+                    ""id"" INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ""raidId"" TEXT NOT NULL,
+                    ""profileId"" TEXT NOT NULL,
+                    ""time"" INTEGER NOT NULL,
+                    ""status"" TEXT NOT NULL,
+                    ""created_at"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (""raidId"") REFERENCES raid(""raidId"")
+                );
+                INSERT INTO player_status_new SELECT * FROM player_status;
+                DROP TABLE player_status;
+                ALTER TABLE player_status_new RENAME TO player_status;
+            "),
         };
 
         foreach (var (name, sql) in migrations)

--- a/ServerMod/ModMetadata.cs
+++ b/ServerMod/ModMetadata.cs
@@ -8,7 +8,7 @@ public record ModMetadata : AbstractModMetadata
     public override string Name { get; init; } = "Raid Review";
     public override string Author { get; init; } = "Ekky";
     public override List<string>? Contributors { get; init; } = ["Chazu"];
-    public override SemanticVersioning.Version Version { get; init; } = new("0.4.0");
+    public override SemanticVersioning.Version Version { get; init; } = new("0.5.0");
     public override SemanticVersioning.Range SptVersion { get; init; } = new("~4.0.0");
     public override List<string>? Incompatibilities { get; init; }
     public override Dictionary<string, SemanticVersioning.Range>? ModDependencies { get; init; }

--- a/ServerMod/ServerMod.csproj
+++ b/ServerMod/ServerMod.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <OutputPath>bin\$(Configuration)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <!-- Copy NuGet runtime deps to output folder -->

--- a/ServerMod/WebSocket/WsPacketHandler.cs
+++ b/ServerMod/WebSocket/WsPacketHandler.cs
@@ -94,7 +94,9 @@ public class WsPacketHandler
             }
             else if (raidId == null && action != "START")
             {
-                _logger.Debug($"[MISSING_VALUE:'raidId'] {action}|{payloadStr}");
+                // PLAYER_CHECK often arrives right after END clears the raidId — expected, suppress noise
+                if (action != "PLAYER_CHECK")
+                    _logger.Debug($"[MISSING_VALUE:'raidId'] {action}|{payloadStr}");
                 return;
             }
 

--- a/publish.sh
+++ b/publish.sh
@@ -3,7 +3,7 @@ set -e
 
 # Configuration
 default_name="raid_review"
-default_version="0.4.0"
+default_version="0.5.0"
 current_dir=$(pwd)
 
 echo "Let's start the deployment process..."
@@ -40,7 +40,7 @@ cd "$current_dir"
 
 # 4. Package server mod
 echo ">> Packaging server mod..."
-server_dest="$dist_folder/user/mods/RaidReview"
+server_dest="$dist_folder/SPT/user/mods/RaidReview"
 mkdir -p "$server_dest"
 
 # Copy DLLs flat (must be next to RaidReview.dll — .NET resolves them before any mod code runs)
@@ -66,7 +66,7 @@ output_path=$(sed -n 's/.*<OutputPath>\(.*\)<\/OutputPath>.*/\1/p' Client/RAID-R
 if [ -z "$output_path" ]; then
     output_path="Client/bin/Release"
 fi
-for file in "$output_path"/RAID_REVIEW__*.dll; do
+for file in "$output_path"/RAID_REVIEW.dll; do
     if [ -f "$file" ]; then
         echo "  Copying $(basename "$file") from $output_path"
         cp "$file" "$client_dest/"


### PR DESCRIPTION
### Bug Fixes
- Fix foreign key constraints to reference `raid.raidId` instead of `raid.id`
- Fix playerFocus using array index instead of profileId (caused hover highlight mismatch on map)

### Faction Mod Support
- Detect and classify bots from **The Mercenary**, **RUAF Come Home**, **UNTAR Go Home**, and **Black Division**
- `MapWildSpawnType()` fallback for bot identification without SAIN
- Prevent SAIN from overriding specific faction types with generic scav
- Partizan boss support with Cyrillic name override
- Added botMapping entries: Partizan, Mercenary, RUAF (6 roles), UNTAR (4 roles), Black Division (4 roles)
- Faction-specific colors: Gold, Steel Blue, Light Blue, Dark Grey

### Map Replay UI Overhaul
- **Grouped legend sidebar** — players organized by category (PMC, Player Scav, Boss, Goons, Followers, Special, Faction, Scav) with collapsible sections, Scav collapsed by default
- **PMC sub-grouping** by team with colored "Team X" headers and numbered markers
- **Faction sub-grouping** by type (Mercenary, RUAF, UNTAR, Black Div) with colored headers
- **Special bot markers** — square markers with letter abbreviations (Ki, Ra, Kn, BP, M, R, Rd, Cu...)
- **PMC numbered circle markers** matching legend
- **Two-pass rendering** — polylines first, markers on top
- **Hover tooltips** on map markers (name + brain/difficulty, EFT-styled)
- **Legend icons match map markers** — squares for specials, numbered circles for PMCs, dots for scavs
- **Killfeed colored dots** next to killer and victim names
- **PMC team colors** — color by team group instead of player index

### Packaging & Install
- Renamed client DLL to `RAID_REVIEW.dll` (no version in filename — simpler upgrades)
- Auto-cleanup of old `RAID_REVIEW__*.dll` on startup
- Fixed release zip structure: added missing `SPT/` root folder
- Bumped all version numbers to 0.5.0