### PR TITLE
0.5.1 — Map data sync & Labyrinth support

### DIFF
--- a/Client/RAID-REVIEW.csproj
+++ b/Client/RAID-REVIEW.csproj
@@ -7,7 +7,7 @@
 		<AssemblyDescription>A post raid review tool for SPT</AssemblyDescription>
 		<AssemblyCompany>EkkyLLC</AssemblyCompany>
 		<AssemblyProduct>RAID_REVIEW</AssemblyProduct>
-		<AssemblyVersion>0.5.0</AssemblyVersion>
+		<AssemblyVersion>0.5.1</AssemblyVersion>
 		<Copyright>2024 © Ekky</Copyright>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<OutputPath>C:\Games\SPT-4.0\BepInEx\plugins\</OutputPath>

--- a/Client/integrations/SAIN.cs
+++ b/Client/integrations/SAIN.cs
@@ -308,6 +308,38 @@ namespace RAID_REVIEW
                             RR_WildSpawnType = "BTR|OTHER";
                             break;
 
+                        // LABYRINTH
+                        case "bossTagillaAgro":
+                            RR_WildSpawnType = "SHADOW TAGILLA|BOSS";
+                            break;
+                        case "bossKillaAgro":
+                            RR_WildSpawnType = "VENGEFUL KILLA|BOSS";
+                            break;
+                        case "tagillaHelperAgro":
+                            RR_WildSpawnType = "SHADOW TAGILLA GUARD|FOLLOWER";
+                            break;
+                        case "infectedAssault":
+                            RR_WildSpawnType = "INFECTED|INFECTED";
+                            break;
+                        case "infectedPmc":
+                            RR_WildSpawnType = "INFECTED PMC|INFECTED";
+                            break;
+                        case "infectedCivil":
+                            RR_WildSpawnType = "INFECTED CIVILIAN|INFECTED";
+                            break;
+                        case "infectedLaborant":
+                            RR_WildSpawnType = "INFECTED LABORANT|INFECTED";
+                            break;
+                        case "infectedTagilla":
+                            RR_WildSpawnType = "INFECTED TAGILLA|BOSS";
+                            break;
+                        case "spiritWinter":
+                            RR_WildSpawnType = "SPIRIT WINTER|SPECIAL";
+                            break;
+                        case "spiritSpring":
+                            RR_WildSpawnType = "SPIRIT SPRING|SPECIAL";
+                            break;
+
                         // THE MERCENARY
                         case "mercenary":
                             RR_WildSpawnType = "MERCENARY|MERCENARY";

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -104,6 +104,17 @@ namespace RAID_REVIEW
                 case "followerKolontaySecurity": return "KOLONTAY SECURITY|FOLLOWER";
                 case "bossPartisan": return "PARTIZAN|BOSS";
                 case "shooterBTR": return "BTR|OTHER";
+                // Labyrinth
+                case "bossTagillaAgro": return "SHADOW TAGILLA|BOSS";
+                case "bossKillaAgro": return "VENGEFUL KILLA|BOSS";
+                case "tagillaHelperAgro": return "SHADOW TAGILLA GUARD|FOLLOWER";
+                case "infectedAssault": return "INFECTED|INFECTED";
+                case "infectedPmc": return "INFECTED PMC|INFECTED";
+                case "infectedCivil": return "INFECTED CIVILIAN|INFECTED";
+                case "infectedLaborant": return "INFECTED LABORANT|INFECTED";
+                case "infectedTagilla": return "INFECTED TAGILLA|BOSS";
+                case "spiritWinter": return "SPIRIT WINTER|SPECIAL";
+                case "spiritSpring": return "SPIRIT SPRING|SPECIAL";
                 // PMC bots
                 case "pmcBEAR": return "PMC|BEAR";
                 case "pmcUSEC": return "PMC|USEC";

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -21,7 +21,7 @@ using EFT.HealthSystem;
 
 namespace RAID_REVIEW
 {
-    [BepInPlugin("ekky.raidreview", "Raid Review", "0.5.0")]
+    [BepInPlugin("ekky.raidreview", "Raid Review", "0.5.1")]
     [BepInDependency("me.sol.sain", BepInDependency.DependencyFlags.SoftDependency)]
     public class RAID_REVIEW : BaseUnityPlugin
     {

--- a/Private/src/assets/botMapping.json
+++ b/Private/src/assets/botMapping.json
@@ -155,6 +155,46 @@
         "name": "BTR",
         "type": "OTHER"
     },
+    "SHADOW TAGILLA|BOSS": {
+        "name": "Shadow of Tagilla",
+        "type": "BOSS"
+    },
+    "VENGEFUL KILLA|BOSS": {
+        "name": "Vengeful Killa",
+        "type": "BOSS"
+    },
+    "SHADOW TAGILLA GUARD|FOLLOWER": {
+        "name": "Shadow Tagilla Guard",
+        "type": "FOLLOWER"
+    },
+    "INFECTED|INFECTED": {
+        "name": "Infected",
+        "type": "INFECTED"
+    },
+    "INFECTED PMC|INFECTED": {
+        "name": "Infected PMC",
+        "type": "INFECTED"
+    },
+    "INFECTED CIVILIAN|INFECTED": {
+        "name": "Infected Civilian",
+        "type": "INFECTED"
+    },
+    "INFECTED LABORANT|INFECTED": {
+        "name": "Infected Laborant",
+        "type": "INFECTED"
+    },
+    "INFECTED TAGILLA|BOSS": {
+        "name": "Infected Tagilla",
+        "type": "BOSS"
+    },
+    "SPIRIT WINTER|SPECIAL": {
+        "name": "Spirit of Winter",
+        "type": "SPECIAL"
+    },
+    "SPIRIT SPRING|SPECIAL": {
+        "name": "Spirit of Spring",
+        "type": "SPECIAL"
+    },
     "CUSTOM|BOSS": {
         "name": "Custom Boss",
         "type": "BOSS"

--- a/Private/src/assets/maps.json
+++ b/Private/src/assets/maps.json
@@ -11,8 +11,8 @@
                 "transform": [0.38, 0, 0.38, 0],
                 "coordinateRotation": 180,
                 "bounds": [
-                    [323, -317],
-                    [-280, 549]
+                    [323, -295],
+                    [-280, 532]
                 ],
                 "heightRange": [-6, 10],
                 "author": "Shebuka",
@@ -361,7 +361,7 @@
                 "author": "Tarkov.dev",
                 "authorLink": "https://tarkov.dev",
                 "svgPath": "https://assets.tarkov.dev/maps/svg/GroundZero-Ground_Level.svg",
-                "tilePath": "https://assets.tarkov.dev/maps/groundzero/main/{z}/{x}/{y}.png",
+                "tilePath": "https://assets.tarkov.dev/maps/groundzero/main_summer/{z}/{x}/{y}.png",
                 "layers": [
                     {
                         "name": "Garage",
@@ -502,12 +502,12 @@
                 "author": "Tarkov.dev",
                 "authorLink": "https://tarkov.dev/",
                 "svgPath": "https://assets.tarkov.dev/maps/svg/Customs-Ground_Level.svg",
-                "tilePath": "https://assets.tarkov.dev/maps/customs_v4/main/{z}/{x}/{y}.png",
+                "tilePath": "https://assets.tarkov.dev/maps/customs_0.16/main/{z}/{x}/{y}.png",
                 "layers": [
                     {
                         "name": "Underground",
                         "svgPath": "https://assets.tarkov.dev/maps/svg/Customs-Underground_Level.svg",
-                        "tilePath": "https://assets.tarkov.dev/maps/customs_v4/underground/{z}/{x}/{y}.png",
+                        "tilePath": "https://assets.tarkov.dev/maps/customs_0.16/underground/{z}/{x}/{y}.png",
                         "show": false,
                         "extents": [
                             {
@@ -525,7 +525,7 @@
                     {
                         "name": "2nd Floor",
                         "svgPath": "https://assets.tarkov.dev/maps/svg/Customs-Second_Floor.svg",
-                        "tilePath": "https://assets.tarkov.dev/maps/customs_v4/2nd/{z}/{x}/{y}.png",
+                        "tilePath": "https://assets.tarkov.dev/maps/customs_0.16/2nd/{z}/{x}/{y}.png",
                         "show": false,
                         "extents": [
                             {
@@ -562,7 +562,7 @@
                     {
                         "name": "3rd Floor",
                         "svgPath": "https://assets.tarkov.dev/maps/svg/Customs-Third_Floor.svg",
-                        "tilePath": "https://assets.tarkov.dev/maps/customs_v4/3rd/{z}/{x}/{y}.png",
+                        "tilePath": "https://assets.tarkov.dev/maps/customs_0.16/3rd/{z}/{x}/{y}.png",
                         "show": false,
                         "extents": [
                             {
@@ -712,18 +712,18 @@
                 "transform": [1.629, 119.9, 1.629, 139.3],
                 "coordinateRotation": 90,
                 "bounds": [
-                    [79, -64.5],
-                    [-66.5, 67.4]
+                    [77, -64.5],
+                    [-65.5, 67.4]
                 ],
                 "heightRange": [-1, 3],
                 "author": "Tarkov.dev",
                 "authorLink": "https://tarkov.dev",
-                "tilePath": "https://assets.tarkov.dev/maps/factory_v2/main/{z}/{x}/{y}.png",
+                "tilePath": "https://assets.tarkov.dev/maps/factory/main/{z}/{x}/{y}.png",
                 "svgPath": "https://assets.tarkov.dev/maps/svg/Factory-Ground_Floor.svg",
                 "layers": [
                     {
                         "name": "2nd Floor",
-                        "tilePath": "https://assets.tarkov.dev/maps/factory_v2/2nd_notint/{z}/{x}/{y}.png",
+                        "tilePath": "https://assets.tarkov.dev/maps/factory/2nd/{z}/{x}/{y}.png",
                         "svgPath": "https://assets.tarkov.dev/maps/svg/Factory-Second_Floor.svg",
                         "show": false,
                         "extents": [
@@ -734,7 +734,7 @@
                     },
                     {
                         "name": "3rd Floor",
-                        "tilePath": "https://assets.tarkov.dev/maps/factory_v2/3rd_notint/{z}/{x}/{y}.png",
+                        "tilePath": "https://assets.tarkov.dev/maps/factory/3rd/{z}/{x}/{y}.png",
                         "svgPath": "https://assets.tarkov.dev/maps/svg/Factory-Third_Floor.svg",
                         "show": false,
                         "extents": [
@@ -745,7 +745,7 @@
                     },
                     {
                         "name": "Tunnels",
-                        "tilePath": "https://assets.tarkov.dev/maps/factory_v2/tunnels_notint/{z}/{x}/{y}.png",
+                        "tilePath": "https://assets.tarkov.dev/maps/factory/tunnels/{z}/{x}/{y}.png",
                         "svgPath": "https://assets.tarkov.dev/maps/svg/Factory-Basement.svg",
                         "show": false,
                         "extents": [
@@ -965,8 +965,8 @@
                 "transform": [0.265, 150.6, 0.265, 134.6],
                 "coordinateRotation": 180,
                 "bounds": [
-                    [530, -439],
-                    [-364, 452]
+                    [598, -442],
+                    [-433, 426]
                 ],
                 "author": "Tarkov.dev",
                 "authorLink": "https://tarkov.dev",
@@ -1556,20 +1556,20 @@
                 "tileSize": 175,
                 "minZoom": 2,
                 "maxZoom": 6,
-                "transform": [0.575, 281.2, 0.575, 196.7],
+                "transform": [0.575, 281.2, 0.575, 193.7],
                 "coordinateRotation": 270,
                 "bounds": [
-                    [-91, -477],
+                    [-80, -477],
                     [-287, -193]
                 ],
                 "author": "Tarkov.dev",
                 "authorLink": "https://tarkov.dev",
-                "tilePath": "https://assets.tarkov.dev/maps/labs_v3/1st/{z}/{x}/{y}.png",
+                "tilePath": "https://assets.tarkov.dev/maps/labs_v4/1st/{z}/{x}/{y}.png",
                 "heightRange": [-0.9, 3],
                 "layers": [
                     {
                         "name": "Second Level",
-                        "tilePath": "https://assets.tarkov.dev/maps/labs_v3/2nd/{z}/{x}/{y}.png",
+                        "tilePath": "https://assets.tarkov.dev/maps/labs_v4/2nd/{z}/{x}/{y}.png",
                         "show": false,
                         "extents": [
                             {
@@ -1585,7 +1585,7 @@
                     },
                     {
                         "name": "Technical",
-                        "tilePath": "https://assets.tarkov.dev/maps/labs_v3/technical/{z}/{x}/{y}.png",
+                        "tilePath": "https://assets.tarkov.dev/maps/labs_v4/technical/{z}/{x}/{y}.png",
                         "show": false,
                         "extents": [
                             {
@@ -1960,15 +1960,20 @@
                 "projection": "interactive",
                 "minZoom": 2,
                 "maxZoom": 6,
-                "transform": [0.268, 0, 0.268, 0],
+                "transform": [0.395, 122.0, 0.395, 137.65],
                 "coordinateRotation": 180,
                 "bounds": [
-                    [289, -338],
-                    [-303, 336]
+                    [289, -293],
+                    [-303, 244]
+                ],
+                "svgBounds": [
+                    [289, -274],
+                    [-303, 272]
                 ],
                 "author": "Shebuka",
-                "authorLink": "https://github.com/TarkovTracker/tarkovdata/",
+                "authorLink": "https://github.com/the-hideout/tarkov-dev-svg-maps/",
                 "svgPath": "https://assets.tarkov.dev/maps/svg/Reserve-Ground_Level.svg",
+                "tilePath": "https://assets.tarkov.dev/maps/reserve/main/{z}/{x}/{y}.png",
                 "heightRange": [-7, 10000],
                 "layers": [
                     {
@@ -2177,14 +2182,14 @@
                 "transform": [0.16, 83.2, 0.16, 111.1],
                 "coordinateRotation": 180,
                 "bounds": [
-                    [508, -415],
-                    [-1060, 618]
+                    [504, -415],
+                    [-1056, 618]
                 ],
                 "heightRange": [-1000, -1],
                 "author": "Shebuka",
                 "authorLink": "https://github.com/TarkovTracker/tarkovdata/",
                 "svgPath": "https://assets.tarkov.dev/maps/svg/Shoreline-Ground_Level.svg",
-                "tilePath": "https://assets.tarkov.dev/maps/shoreline/main/{z}/{x}/{y}.png",
+                "tilePath": "https://assets.tarkov.dev/maps/shoreline/main_summer/{z}/{x}/{y}.png",
                 "layers": [
                     {
                         "name": "Underground",
@@ -2366,18 +2371,18 @@
             {
                 "key": "woods",
                 "projection": "interactive",
-                "minZoom": 1,
+                "minZoom": 2,
                 "maxZoom": 6,
-                "transform": [0.1855, 113.1, 0.1855, 167.8],
+                "transform": [0.1855, 112.95, 0.1855, 167.85],
                 "coordinateRotation": 180,
                 "bounds": [
-                    [650, -945],
-                    [-695, 470]
+                    [646, -914],
+                    [-761, 442]
                 ],
                 "author": "Shebuka",
-                "authorLink": "https://github.com/TarkovTracker/tarkovdata/",
+                "authorLink": "https://github.com/the-hideout/tarkov-dev-svg-maps/",
                 "svgPath": "https://assets.tarkov.dev/maps/svg/Woods.svg",
-                "tilePath": "https://assets.tarkov.dev/maps/woods/main/{z}/{x}/{y}.png",
+                "tilePath": "https://assets.tarkov.dev/maps/woods/main_0.16/{z}/{x}/{y}.png",
                 "labels": [
                     {
                         "position": [10, -3],
@@ -2466,6 +2471,28 @@
                 "projection": "3D",
                 "author": "re3mr",
                 "authorLink": "https://reemr.se"
+            }
+        ]
+    },
+    {
+        "normalizedName": "the-labyrinth",
+        "primaryPath": "/map/labyrinth",
+        "maps": [
+            {
+                "key": "the-labyrinth",
+                "projection": "interactive",
+                "minZoom": 1,
+                "maxZoom": 6,
+                "transform": [2.115, 85.5, 2.115, 128.0],
+                "coordinateRotation": 270,
+                "bounds": [
+                    [-52, -37],
+                    [53, 76]
+                ],
+                "author": "Tarkov.dev",
+                "authorLink": "https://tarkov.dev",
+                "tilePath": "https://assets.tarkov.dev/maps/labyrinth/main/{z}/{x}/{y}.png",
+                "labels": []
             }
         ]
     },

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -418,6 +418,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
             town: 'town',
             woods: 'woods',
             Woods: 'woods',
+            Labyrinth: 'the-labyrinth',
             base: 'base',
         }
 

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -46,7 +46,8 @@ function classifyPlayer(player: any): string {
         case 'ROGUE':
         case 'CULT':
         case 'BLOODHOUND':
-        case 'SNIPER': return 'SPECIAL'
+        case 'SNIPER':
+        case 'INFECTED': return 'SPECIAL'
         case 'MERCENARY':
         case 'RUAF':
         case 'UNTAR':
@@ -108,6 +109,12 @@ function getMarkerLabel(player: any): string | null {
     if (type.includes('RUAF')) return 'R'
     if (type.includes('UNTAR')) return 'U'
     if (type.includes('BLACK DIV')) return 'BD'
+
+    // Labyrinth
+    if (type.includes('SHADOW TAGILLA')) return 'ST'
+    if (type.includes('VENGEFUL KILLA')) return 'VK'
+    if (type.includes('INFECTED')) return 'If'
+    if (type.includes('SPIRIT')) return 'Sp'
 
     // Special types
     if (type.includes('RAIDER')) return 'Rd'
@@ -370,12 +377,18 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
     const mapData = useMemo(() => {
         const map = allMaps[currentMap]
 
-        if (map && map.layers) {
-            let newAvailableLayers = map.layers.map((x) => ({ name: x.name, value: x.name }))
+        if (map) {
+            let newAvailableLayers = (map.layers || []).map((x) => ({ name: x.name, value: x.name }))
             setAvailableLayers([{ name: 'Base', value: '' }, ...newAvailableLayers])
 
             let newAvailableStyles = [!map.tilePath || { name: 'Satellite', value: 'tile' }, !map.svgPath || { name: 'Map', value: 'svg' }].filter((f) => f)
             serAvailableStyles(newAvailableStyles)
+
+            // Auto-select first available style if current style isn't available
+            setSelectedStyle(prev => {
+                const hasStyle = newAvailableStyles.some((s) => s.value === prev)
+                return hasStyle ? prev : (newAvailableStyles[0]?.value || prev)
+            })
         }
 
         return map
@@ -1055,6 +1068,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
             if (botMapping.type === 'SNIPER') brainOutput = `Sniper`
             if (botMapping.type === 'PLAYER_SCAV') brainOutput = `${player.mod_SAIN_brain.trim()} - Player Scav`
             if (botMapping.type === 'BLOODHOUND') brainOutput = `Bloodhound`
+            if (botMapping.type === 'INFECTED') brainOutput = `Infected`
 
             return brainOutput
         }
@@ -1121,6 +1135,8 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                 return '#00BFFF' // Light Blue - UNTAR
             case 'BLACKDIV':
                 return '#555555' // Dark Grey - Black Division
+            case 'INFECTED':
+                return '#7FFF00' // Chartreuse - Infected (Labyrinth)
             default:
                 if (player.type === 'PLAYER' && player.team === 'Savage') return '#33FF57' // Green - Scav
                 else return colors[(player.group ?? index) % colors.length] // PMC - color by team group

--- a/Private/src/modules/maps-index.js
+++ b/Private/src/modules/maps-index.js
@@ -87,5 +87,6 @@ export const mapIcons = {
     'reserve': '',
     'shoreline': '',
     'woods': '',
+    'the-labyrinth': '',
     'openworld': '',
 };

--- a/ServerMod/ModMetadata.cs
+++ b/ServerMod/ModMetadata.cs
@@ -8,7 +8,7 @@ public record ModMetadata : AbstractModMetadata
     public override string Name { get; init; } = "Raid Review";
     public override string Author { get; init; } = "Ekky";
     public override List<string>? Contributors { get; init; } = ["Chazu"];
-    public override SemanticVersioning.Version Version { get; init; } = new("0.5.0");
+    public override SemanticVersioning.Version Version { get; init; } = new("0.5.1");
     public override SemanticVersioning.Range SptVersion { get; init; } = new("~4.0.0");
     public override List<string>? Incompatibilities { get; init; }
     public override Dictionary<string, SemanticVersioning.Range>? ModDependencies { get; init; }

--- a/ServerMod/ServerMod.csproj
+++ b/ServerMod/ServerMod.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <OutputPath>bin\$(Configuration)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <!-- Copy NuGet runtime deps to output folder -->

--- a/publish.sh
+++ b/publish.sh
@@ -3,7 +3,7 @@ set -e
 
 # Configuration
 default_name="raid_review"
-default_version="0.5.0"
+default_version="0.5.1"
 current_dir=$(pwd)
 
 echo "Let's start the deployment process..."


### PR DESCRIPTION
## Summary

- **Map data synced with tarkov.dev**: Updated transforms, bounds, and tile paths for all interactive maps to match the latest tarkov.dev source data
  - Woods, Customs, Shoreline: recalibrated tile versions (`main_0.16`, `customs_0.16`, `main_summer`)
  - Ground Zero, Shoreline: summer tile variants
  - Reserve: added satellite tile rendering + corrected transform/bounds
  - Factory, Interchange, Streets, The Lab: corrected bounds and tile versions (`labs_v4`, `factory`)
- **Labyrinth**: Added as a new supported map with satellite tiles and location ID mapping
- **Fixes position offset on Woods**: Player dots now align correctly with the map background