### PR TITLE
Release 1.0.0: Loot value tracking, bot behavior & inventory, full UI overhaul

### DIFF
--- a/Client/RAID-REVIEW.csproj
+++ b/Client/RAID-REVIEW.csproj
@@ -7,7 +7,7 @@
 		<AssemblyDescription>A post raid review tool for SPT</AssemblyDescription>
 		<AssemblyCompany>EkkyLLC</AssemblyCompany>
 		<AssemblyProduct>RAID_REVIEW</AssemblyProduct>
-		<AssemblyVersion>0.5.1</AssemblyVersion>
+		<AssemblyVersion>1.0.0</AssemblyVersion>
 		<Copyright>2024 © Ekky</Copyright>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<OutputPath>C:\Games\SPT-4.0\BepInEx\plugins\</OutputPath>

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -151,11 +151,22 @@ namespace RAID_REVIEW
         private static bool _sainReflectionInit = false;
         private static bool _sainAvailable = false;
         private static Type _sainBotComponentType;
+        private static Type _sainBotControllerType;
         private static PropertyInfo _sainActiveLayerProp;
         private static PropertyInfo _sainDecisionProp;
         private static PropertyInfo _sainCombatDecProp;
         private static PropertyInfo _sainSelfDecProp;
         private static PropertyInfo _sainSquadDecProp;
+        private static PropertyInfo _sainCurrentActionProp;
+        private static PropertyInfo _sainActionNameProp;
+        private static PropertyInfo _sainBotsProp;
+        private static PropertyInfo _sainBotPlayerProp;
+        private static PropertyInfo _sainBotProfileIdProp;
+        private static PropertyInfo _sainMoverProp;
+        private static PropertyInfo _sainMoverMovingProp;
+        private static PropertyInfo _sainMoverSprintProp;
+        private static PropertyInfo _sainStandByProp;
+        private static PropertyInfo _sainLayersActiveProp;
 
         private static void InitSainReflection()
         {
@@ -163,15 +174,19 @@ namespace RAID_REVIEW
             _sainReflectionInit = true;
             try
             {
-                var sainAssembly = AppDomain.CurrentDomain.GetAssemblies()
-                    .FirstOrDefault(a => a.GetName().Name == "SAIN");
-                if (sainAssembly == null) return;
+                _sainBotComponentType = Type.GetType("SAIN.Components.BotComponent, SAIN");
+                _sainBotControllerType = Type.GetType("SAIN.Components.BotManagerComponent, SAIN");
 
-                _sainBotComponentType = sainAssembly.GetType("SAIN.Components.BotComponent");
-                if (_sainBotComponentType == null) return;
+                if (_sainBotComponentType == null)
+                {
+                    LoggerInstance.Log.LogWarning("RAID_REVIEW :::: SAIN :::: BotComponent type not found");
+                    return;
+                }
 
                 _sainActiveLayerProp = _sainBotComponentType.GetProperty("ActiveLayer");
                 _sainDecisionProp = _sainBotComponentType.GetProperty("Decision");
+                _sainCurrentActionProp = _sainBotComponentType.GetProperty("CurrentAction");
+                _sainBotPlayerProp = _sainBotComponentType.GetProperty("Player");
 
                 if (_sainDecisionProp != null)
                 {
@@ -181,57 +196,197 @@ namespace RAID_REVIEW
                     _sainSquadDecProp = decClassType?.GetProperty("CurrentSquadDecision");
                 }
 
+                if (_sainCurrentActionProp != null)
+                {
+                    _sainActionNameProp = _sainCurrentActionProp.PropertyType?.GetProperty("Name");
+                }
+
+                if (_sainBotControllerType != null)
+                {
+                    _sainBotsProp = _sainBotControllerType.GetProperty("Bots");
+                }
+
+                if (_sainBotPlayerProp != null)
+                {
+                    _sainBotProfileIdProp = _sainBotPlayerProp.PropertyType?.GetProperty("ProfileId");
+                }
+
+                // Movement/state properties for peace mode granularity
+                _sainMoverProp = _sainBotComponentType.GetProperty("Mover");
+                _sainStandByProp = _sainBotComponentType.GetProperty("BotInStandBy");
+                _sainLayersActiveProp = _sainBotComponentType.GetProperty("SAINLayersActive");
+
+                if (_sainMoverProp != null)
+                {
+                    var moverType = _sainMoverProp.PropertyType;
+                    _sainMoverMovingProp = moverType?.GetProperty("Moving");
+                    _sainMoverSprintProp = moverType?.GetProperty("SprintController");
+                    // Try "Running" as fallback
+                    if (_sainMoverSprintProp == null)
+                        _sainMoverSprintProp = moverType?.GetProperty("Running");
+                }
+
                 _sainAvailable = true;
+
+                LoggerInstance.Log.LogInfo($"RAID_REVIEW :::: SAIN :::: Reflection init OK — " +
+                    $"Decision={_sainDecisionProp != null}, Combat={_sainCombatDecProp != null}, " +
+                    $"Self={_sainSelfDecProp != null}, Squad={_sainSquadDecProp != null}, " +
+                    $"Action={_sainCurrentActionProp != null}, ActionName={_sainActionNameProp != null}, " +
+                    $"ActiveLayer={_sainActiveLayerProp != null}, " +
+                    $"Controller={_sainBotControllerType != null}, Bots={_sainBotsProp != null}, " +
+                    $"Mover={_sainMoverProp != null}, Moving={_sainMoverMovingProp != null}, " +
+                    $"StandBy={_sainStandByProp != null}, LayersActive={_sainLayersActiveProp != null}");
+            }
+            catch (Exception ex)
+            {
+                LoggerInstance.Log.LogWarning($"RAID_REVIEW :::: SAIN :::: Reflection init failed: {ex.Message}");
+            }
+        }
+
+        // Cache: profileId → SAIN BotComponent (rebuilt each position tick)
+        private static Dictionary<string, object> _sainBotCache = new Dictionary<string, object>();
+
+        private static void RefreshSainBotCache()
+        {
+            _sainBotCache.Clear();
+            try
+            {
+                // Use the already-discovered sainBotController from SAIN_Integration
+                var controller = RAID_REVIEW.sainBotController;
+                if (controller == null || _sainBotsProp == null) return;
+
+                var bots = _sainBotsProp.GetValue(controller);
+                if (bots == null) return;
+
+                var botValues = (IEnumerable)bots.GetType().GetProperty("Values")?.GetValue(bots);
+                if (botValues == null) return;
+
+                foreach (var botComp in botValues)
+                {
+                    try
+                    {
+                        string profileId = null;
+                        if (_sainBotPlayerProp != null)
+                        {
+                            var playerObj = _sainBotPlayerProp.GetValue(botComp);
+                            if (playerObj != null && _sainBotProfileIdProp != null)
+                                profileId = _sainBotProfileIdProp.GetValue(playerObj)?.ToString();
+                        }
+                        if (!string.IsNullOrEmpty(profileId))
+                            _sainBotCache[profileId] = botComp;
+                    }
+                    catch { }
+                }
             }
             catch { }
         }
 
+        private static string ExtractDecisionFromBotComp(object botComp)
+        {
+            if (botComp == null) return null;
+
+            if (_sainDecisionProp != null)
+            {
+                var decisionObj = _sainDecisionProp.GetValue(botComp);
+                if (decisionObj != null)
+                {
+                    // Self decisions (FirstAid, Reload, Surgery, Stims) take priority
+                    if (_sainSelfDecProp != null)
+                    {
+                        var selfDec = _sainSelfDecProp.GetValue(decisionObj)?.ToString();
+                        if (!string.IsNullOrEmpty(selfDec) && selfDec != "None" && selfDec != "0")
+                            return "SAIN:" + selfDec;
+                    }
+
+                    // Combat decisions (Search, StandAndShoot, DogFight, etc.)
+                    if (_sainCombatDecProp != null)
+                    {
+                        var combatDec = _sainCombatDecProp.GetValue(decisionObj)?.ToString();
+                        if (!string.IsNullOrEmpty(combatDec) && combatDec != "None" && combatDec != "0")
+                            return "SAIN:" + combatDec;
+                    }
+
+                    // Squad decisions (Regroup, Suppress, Help, etc.)
+                    if (_sainSquadDecProp != null)
+                    {
+                        var squadDec = _sainSquadDecProp.GetValue(decisionObj)?.ToString();
+                        if (!string.IsNullOrEmpty(squadDec) && squadDec != "None" && squadDec != "0")
+                            return "SAIN:" + squadDec;
+                    }
+                }
+            }
+
+            // CurrentAction.Name
+            if (_sainCurrentActionProp != null && _sainActionNameProp != null)
+            {
+                var actionObj = _sainCurrentActionProp.GetValue(botComp);
+                if (actionObj != null)
+                {
+                    var actionName = _sainActionNameProp.GetValue(actionObj)?.ToString();
+                    if (!string.IsNullOrEmpty(actionName))
+                        return "SAIN:" + actionName;
+                }
+            }
+
+            // Fallback to active layer name (Combat, Peace, Extract, etc.)
+            if (_sainActiveLayerProp != null)
+            {
+                var layer = _sainActiveLayerProp.GetValue(botComp)?.ToString();
+                if (!string.IsNullOrEmpty(layer) && layer != "None" && layer != "0")
+                    return "SAIN:" + layer;
+            }
+
+            // Bot is managed by SAIN but all decisions are "None" — check movement state
+            try
+            {
+                // Check if bot is in AI-limiter standby (not actually doing anything)
+                if (_sainStandByProp != null)
+                {
+                    var standBy = _sainStandByProp.GetValue(botComp);
+                    if (standBy is true)
+                        return "SAIN:standBy";
+                }
+
+                // Check Mover.Moving to distinguish patrol from idle
+                if (_sainMoverProp != null && _sainMoverMovingProp != null)
+                {
+                    var mover = _sainMoverProp.GetValue(botComp);
+                    if (mover != null)
+                    {
+                        var moving = _sainMoverMovingProp.GetValue(mover);
+                        if (moving is true)
+                            return "SAIN:simplePatrol";
+                    }
+                }
+            }
+            catch { }
+
+            // Truly idle — no SAIN decision, not moving
+            return "SAIN:peaceful";
+        }
+
         private static string GetSainDecision(Player player)
         {
-            if (!_sainAvailable || _sainBotComponentType == null) return null;
+            if (!_sainAvailable) return null;
 
             try
             {
-                var botComp = player.gameObject.GetComponent(_sainBotComponentType);
-                if (botComp == null) return null;
-
-                if (_sainDecisionProp != null)
+                // Primary: lookup from BotManagerComponent.Bots dictionary (populated by SAIN_Integration)
+                if (_sainBotCache.TryGetValue(player.ProfileId, out var cachedComp))
                 {
-                    var decisionObj = _sainDecisionProp.GetValue(botComp);
-                    if (decisionObj != null)
-                    {
-                        // Self decisions (FirstAid, Reload, Surgery, Stims) take priority
-                        if (_sainSelfDecProp != null)
-                        {
-                            var selfDec = _sainSelfDecProp.GetValue(decisionObj)?.ToString();
-                            if (!string.IsNullOrEmpty(selfDec) && selfDec != "None" && selfDec != "0")
-                                return "SAIN:" + selfDec;
-                        }
-
-                        // Combat decisions (Search, StandAndShoot, DogFight, etc.)
-                        if (_sainCombatDecProp != null)
-                        {
-                            var combatDec = _sainCombatDecProp.GetValue(decisionObj)?.ToString();
-                            if (!string.IsNullOrEmpty(combatDec) && combatDec != "None" && combatDec != "0")
-                                return "SAIN:" + combatDec;
-                        }
-
-                        // Squad decisions (Regroup, Suppress, Help, etc.)
-                        if (_sainSquadDecProp != null)
-                        {
-                            var squadDec = _sainSquadDecProp.GetValue(decisionObj)?.ToString();
-                            if (!string.IsNullOrEmpty(squadDec) && squadDec != "None" && squadDec != "0")
-                                return "SAIN:" + squadDec;
-                        }
-                    }
+                    var result = ExtractDecisionFromBotComp(cachedComp);
+                    if (result != null) return result;
                 }
 
-                // Fallback to active layer name (Combat, Peace, Extract, etc.)
-                if (_sainActiveLayerProp != null)
+                // Fallback: try GetComponent directly on player's gameObject
+                if (_sainBotComponentType != null)
                 {
-                    var layer = _sainActiveLayerProp.GetValue(botComp)?.ToString();
-                    if (!string.IsNullOrEmpty(layer) && layer != "None" && layer != "0")
-                        return "SAIN:" + layer;
+                    var botComp = player.gameObject.GetComponent(_sainBotComponentType);
+                    if (botComp != null)
+                    {
+                        var result = ExtractDecisionFromBotComp(botComp);
+                        if (result != null) return result;
+                    }
                 }
             }
             catch { }
@@ -344,6 +499,13 @@ namespace RAID_REVIEW
                     // PLAYER TRACKING LOOP
                     IEnumerable<Player> allPlayers = gameWorld.AllPlayersEverExisted;
                     long captureTime = stopwatch.ElapsedMilliseconds;
+
+                    // Refresh SAIN bot cache once per tick (before iterating players)
+                    if (SOLARINT_SAIN__DETECTED)
+                    {
+                        InitSainReflection();
+                        RefreshSainBotCache();
+                    }
                     foreach (Player player in allPlayers)
                     {
 
@@ -451,8 +613,6 @@ namespace RAID_REVIEW
                                 {
                                     try
                                     {
-                                        InitSainReflection();
-
                                         // Try SAIN reflection first for meaningful decision names
                                         var sainDec = GetSainDecision(player);
                                         if (!string.IsNullOrEmpty(sainDec))
@@ -461,12 +621,12 @@ namespace RAID_REVIEW
                                         }
                                         else
                                         {
-                                            // Vanilla fallback — skip BigBrain custom IDs (>= 9000)
+                                            // Vanilla fallback — always send, even BigBrain IDs (frontend maps 9000+)
                                             var botOwner = player.AIData?.BotOwner;
                                             if (botOwner?.Brain != null)
                                             {
                                                 var lastDecision = botOwner.Brain.LastDecision;
-                                                if (lastDecision.HasValue && (int)lastDecision.Value < 9000)
+                                                if (lastDecision.HasValue)
                                                     decision = lastDecision.Value.ToString();
                                             }
                                         }

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -18,6 +18,8 @@ using System.Threading.Tasks;
 using System.Linq;
 using System.Collections;
 using EFT.HealthSystem;
+using EFT.InventoryLogic;
+using EFT.Interactive;
 
 namespace RAID_REVIEW
 {
@@ -394,6 +396,100 @@ namespace RAID_REVIEW
             return null;
         }
 
+        /// <summary>Get handbook base price for an item (0 if handbook unavailable).</summary>
+        public static int GetHandbookPrice(Item item)
+        {
+            try { return (int)Singleton<HandbookClass>.Instance.GetBasePrice(item.TemplateId); }
+            catch { return 0; }
+        }
+
+        // ── Loose Loot Capture ──
+        private static bool _looseLootCaptured = false;
+        public static void ResetLooseLootFlag() { _looseLootCaptured = false; }
+
+        private void CaptureLooseLoot()
+        {
+            if (_looseLootCaptured || gameWorld == null) return;
+            _looseLootCaptured = true;
+
+            try
+            {
+                var items = new List<TrackingLooseLootItem>();
+                var seenIds = new HashSet<string>();
+
+                foreach (var lootPoint in gameWorld.LootList)
+                {
+                    try
+                    {
+                        if (lootPoint is LootItem lootItem)
+                        {
+                            var item = lootItem.Item;
+                            if (item == null) continue;
+                            if (!seenIds.Add(item.Id)) continue;
+                            var pos = lootItem.transform.position;
+                            items.Add(new TrackingLooseLootItem
+                            {
+                                itemId = item.Id,
+                                templateId = item.TemplateId.ToString(),
+                                itemName = item.LocalizedShortName(),
+                                price = GetHandbookPrice(item),
+                                qty = item.StackObjectsCount,
+                                x = pos.x, y = pos.y, z = pos.z,
+                                inContainer = false,
+                                containerName = ""
+                            });
+                        }
+                        else if (lootPoint is LootableContainer container)
+                        {
+                            var rootItem = container.ItemOwner?.RootItem;
+                            if (rootItem is CompoundItem compound)
+                            {
+                                var pos = container.transform.position;
+                                var cName = "";
+                                try { cName = rootItem.LocalizedShortName(); } catch { }
+                                foreach (var grid in compound.Grids)
+                                {
+                                    foreach (var contained in grid.Items)
+                                    {
+                                        if (contained == null) continue;
+                                        if (!seenIds.Add(contained.Id)) continue;
+                                        items.Add(new TrackingLooseLootItem
+                                        {
+                                            itemId = contained.Id,
+                                            templateId = contained.TemplateId.ToString(),
+                                            itemName = contained.LocalizedShortName(),
+                                            price = GetHandbookPrice(contained),
+                                            qty = contained.StackObjectsCount,
+                                            x = pos.x, y = pos.y, z = pos.z,
+                                            inContainer = true,
+                                            containerName = cName
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    catch { }
+                }
+
+                if (items.Count > 0)
+                {
+                    Logger.LogInfo($"RAID_REVIEW :::: INFO :::: Captured {items.Count} loose loot items");
+                    var payload = new TrackingLooseLoot
+                    {
+                        sessionId = sessionId,
+                        time = stopwatch.ElapsedMilliseconds,
+                        items = items
+                    };
+                    _ = Telemetry.Send("LOOSE_LOOT", JsonConvert.SerializeObject(payload));
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning($"RAID_REVIEW :::: WARN :::: Loose loot capture failed: {ex.Message}");
+            }
+        }
+
         void Awake()
         {
             Logger.LogInfo("RAID_REVIEW :::: INFO :::: Mod Loaded");
@@ -496,6 +592,9 @@ namespace RAID_REVIEW
                         continue;
                     }
 
+                    // Capture loose loot once per raid (first tick after raid start)
+                    CaptureLooseLoot();
+
                     // PLAYER TRACKING LOOP
                     IEnumerable<Player> allPlayers = gameWorld.AllPlayersEverExisted;
                     long captureTime = stopwatch.ElapsedMilliseconds;
@@ -557,6 +656,39 @@ namespace RAID_REVIEW
 
                             trackingPlayers[trackingPlayer.profileId] = trackingPlayer;
                             _ = Telemetry.Send("PLAYER", JsonConvert.SerializeObject(trackingPlayer));
+
+                            // Capture bot inventory at spawn
+                            if (player.IsAI)
+                            {
+                                try
+                                {
+                                    var invItems = new List<TrackingInventoryItem>();
+                                    foreach (var item in player.Inventory.GetPlayerItems(EPlayerItems.Equipment))
+                                    {
+                                        if (item == null) continue;
+                                        invItems.Add(new TrackingInventoryItem
+                                        {
+                                            templateId = item.TemplateId.ToString(),
+                                            itemName = item.LocalizedShortName(),
+                                            price = GetHandbookPrice(item),
+                                            qty = item.StackObjectsCount,
+                                            slot = item.Parent?.Container?.ID ?? "unknown"
+                                        });
+                                    }
+                                    if (invItems.Count > 0)
+                                    {
+                                        var invPayload = new TrackingPlayerInventory
+                                        {
+                                            sessionId = sessionId,
+                                            profileId = player.ProfileId,
+                                            time = stopwatch.ElapsedMilliseconds,
+                                            items = invItems
+                                        };
+                                        _ = Telemetry.Send("PLAYER_INVENTORY", JsonConvert.SerializeObject(invPayload));
+                                    }
+                                }
+                                catch { }
+                            }
 
                         }
 

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -147,6 +147,98 @@ namespace RAID_REVIEW
         public static bool searchingForSainComponents = false;
         public static Dictionary<string, TrackingPlayer> updatedBots = new Dictionary<string, TrackingPlayer>();
 
+        // SAIN reflection cache
+        private static bool _sainReflectionInit = false;
+        private static bool _sainAvailable = false;
+        private static Type _sainBotComponentType;
+        private static PropertyInfo _sainActiveLayerProp;
+        private static PropertyInfo _sainDecisionProp;
+        private static PropertyInfo _sainCombatDecProp;
+        private static PropertyInfo _sainSelfDecProp;
+        private static PropertyInfo _sainSquadDecProp;
+
+        private static void InitSainReflection()
+        {
+            if (_sainReflectionInit) return;
+            _sainReflectionInit = true;
+            try
+            {
+                var sainAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                    .FirstOrDefault(a => a.GetName().Name == "SAIN");
+                if (sainAssembly == null) return;
+
+                _sainBotComponentType = sainAssembly.GetType("SAIN.Components.BotComponent");
+                if (_sainBotComponentType == null) return;
+
+                _sainActiveLayerProp = _sainBotComponentType.GetProperty("ActiveLayer");
+                _sainDecisionProp = _sainBotComponentType.GetProperty("Decision");
+
+                if (_sainDecisionProp != null)
+                {
+                    var decClassType = _sainDecisionProp.PropertyType;
+                    _sainCombatDecProp = decClassType?.GetProperty("CurrentCombatDecision");
+                    _sainSelfDecProp = decClassType?.GetProperty("CurrentSelfDecision");
+                    _sainSquadDecProp = decClassType?.GetProperty("CurrentSquadDecision");
+                }
+
+                _sainAvailable = true;
+            }
+            catch { }
+        }
+
+        private static string GetSainDecision(Player player)
+        {
+            if (!_sainAvailable || _sainBotComponentType == null) return null;
+
+            try
+            {
+                var botComp = player.gameObject.GetComponent(_sainBotComponentType);
+                if (botComp == null) return null;
+
+                if (_sainDecisionProp != null)
+                {
+                    var decisionObj = _sainDecisionProp.GetValue(botComp);
+                    if (decisionObj != null)
+                    {
+                        // Self decisions (FirstAid, Reload, Surgery, Stims) take priority
+                        if (_sainSelfDecProp != null)
+                        {
+                            var selfDec = _sainSelfDecProp.GetValue(decisionObj)?.ToString();
+                            if (!string.IsNullOrEmpty(selfDec) && selfDec != "None" && selfDec != "0")
+                                return "SAIN:" + selfDec;
+                        }
+
+                        // Combat decisions (Search, StandAndShoot, DogFight, etc.)
+                        if (_sainCombatDecProp != null)
+                        {
+                            var combatDec = _sainCombatDecProp.GetValue(decisionObj)?.ToString();
+                            if (!string.IsNullOrEmpty(combatDec) && combatDec != "None" && combatDec != "0")
+                                return "SAIN:" + combatDec;
+                        }
+
+                        // Squad decisions (Regroup, Suppress, Help, etc.)
+                        if (_sainSquadDecProp != null)
+                        {
+                            var squadDec = _sainSquadDecProp.GetValue(decisionObj)?.ToString();
+                            if (!string.IsNullOrEmpty(squadDec) && squadDec != "None" && squadDec != "0")
+                                return "SAIN:" + squadDec;
+                        }
+                    }
+                }
+
+                // Fallback to active layer name (Combat, Peace, Extract, etc.)
+                if (_sainActiveLayerProp != null)
+                {
+                    var layer = _sainActiveLayerProp.GetValue(botComp)?.ToString();
+                    if (!string.IsNullOrEmpty(layer) && layer != "None" && layer != "0")
+                        return "SAIN:" + layer;
+                }
+            }
+            catch { }
+
+            return null;
+        }
+
         void Awake()
         {
             Logger.LogInfo("RAID_REVIEW :::: INFO :::: Mod Loaded");
@@ -353,7 +445,36 @@ namespace RAID_REVIEW
                                 float currentHealth = commonHealth.Current;
                                 float currentHealthMaximum = commonHealth.Current;
 
-                                var trackingPlayerData = new TrackingPlayerData(sessionId, player.ProfileId, captureTime, playerPosition.x, playerPosition.y, playerPosition.z, dir, currentHealth, currentHealthMaximum);
+                                // Bot behavior state
+                                string decision = "";
+                                if (player.IsAI)
+                                {
+                                    try
+                                    {
+                                        InitSainReflection();
+
+                                        // Try SAIN reflection first for meaningful decision names
+                                        var sainDec = GetSainDecision(player);
+                                        if (!string.IsNullOrEmpty(sainDec))
+                                        {
+                                            decision = sainDec;
+                                        }
+                                        else
+                                        {
+                                            // Vanilla fallback — skip BigBrain custom IDs (>= 9000)
+                                            var botOwner = player.AIData?.BotOwner;
+                                            if (botOwner?.Brain != null)
+                                            {
+                                                var lastDecision = botOwner.Brain.LastDecision;
+                                                if (lastDecision.HasValue && (int)lastDecision.Value < 9000)
+                                                    decision = lastDecision.Value.ToString();
+                                            }
+                                        }
+                                    }
+                                    catch { }
+                                }
+
+                                var trackingPlayerData = new TrackingPlayerData(sessionId, player.ProfileId, captureTime, playerPosition.x, playerPosition.y, playerPosition.z, dir, currentHealth, currentHealthMaximum, decision);
                                 _ = Telemetry.Send("POSITION", JsonConvert.SerializeObject(trackingPlayerData));
                             }
 

--- a/Client/models/Tracking.cs
+++ b/Client/models/Tracking.cs
@@ -118,6 +118,7 @@ namespace RAID_REVIEW
         public string profileId { get; set; }
         public long time { get; set; }
         public string weaponId { get; set; }
+        public string weaponName { get; set; }
         public string ammoId { get; set; }
         public string hitPlayerId { get; set; }
         public string source { get; set; }

--- a/Client/models/Tracking.cs
+++ b/Client/models/Tracking.cs
@@ -73,17 +73,19 @@ namespace RAID_REVIEW
         public float dir { get; set; }
         public float health { get; set; }
         public float maxHealth { get; set; }
+        public string decision { get; set; }
 
         public TrackingPlayerData(
-            string sessionId, 
-            string profileId, 
-            long time, 
-            float x, 
-            float y, 
-            float z, 
+            string sessionId,
+            string profileId,
+            long time,
+            float x,
+            float y,
+            float z,
             float dir,
             float health,
-            float maxHealth
+            float maxHealth,
+            string decision = ""
         )
         {
             this.sessionId = sessionId;
@@ -95,6 +97,7 @@ namespace RAID_REVIEW
             this.dir = dir;
             this.health = health;
             this.maxHealth = maxHealth;
+            this.decision = decision;
         }
     }
 

--- a/Client/models/Tracking.cs
+++ b/Client/models/Tracking.cs
@@ -56,10 +56,15 @@ namespace RAID_REVIEW
         public string profileId { get; set; }
         public long time { get; set; }
         public string itemId { get; set; }
+        public string templateId { get; set; }
         public string itemName { get; set; }
+        public int price { get; set; }
         public int qty { get; set; }
         public string type { get; set; }
         public bool added {  get; set; }
+        public float x { get; set; }
+        public float y { get; set; }
+        public float z { get; set; }
     }
 
     public class TrackingPlayerData
@@ -126,5 +131,43 @@ namespace RAID_REVIEW
         public string hitPlayerId { get; set; }
         public string source { get; set; }
         public string target { get; set; }
+    }
+
+    public class TrackingLooseLoot
+    {
+        public string sessionId { get; set; }
+        public long time { get; set; }
+        public List<TrackingLooseLootItem> items { get; set; }
+    }
+
+    public class TrackingLooseLootItem
+    {
+        public string itemId { get; set; }
+        public string templateId { get; set; }
+        public string itemName { get; set; }
+        public int price { get; set; }
+        public int qty { get; set; }
+        public float x { get; set; }
+        public float y { get; set; }
+        public float z { get; set; }
+        public bool inContainer { get; set; }
+        public string containerName { get; set; }
+    }
+
+    public class TrackingPlayerInventory
+    {
+        public string sessionId { get; set; }
+        public string profileId { get; set; }
+        public long time { get; set; }
+        public List<TrackingInventoryItem> items { get; set; }
+    }
+
+    public class TrackingInventoryItem
+    {
+        public string templateId { get; set; }
+        public string itemName { get; set; }
+        public int price { get; set; }
+        public int qty { get; set; }
+        public string slot { get; set; }
     }
 }

--- a/Client/patches/clientGameWorld_ShotDelegatePatch.cs
+++ b/Client/patches/clientGameWorld_ShotDelegatePatch.cs
@@ -37,6 +37,7 @@ namespace RAID_REVIEW
                     sessionId = RAID_REVIEW.sessionId,
                     profileId = shotResult.PlayerProfileID,
                     weaponId = shotResult.Weapon.Id,
+                    weaponName = shotResult.Weapon.LocalizedShortName(),
                     ammoId = shotResult.Ammo.Id,
                     time = RAID_REVIEW.stopwatch.ElapsedMilliseconds,
                     hitPlayerId = hitPlayerId ?? null,

--- a/Client/patches/player_onGameStartedPatch.cs
+++ b/Client/patches/player_onGameStartedPatch.cs
@@ -64,6 +64,7 @@ namespace RAID_REVIEW
                 Telemetry.Send("PLAYER", JsonConvert.SerializeObject(newTrackingPlayer));
 
                 RAID_REVIEW.inRaid = true;
+                RAID_REVIEW.ResetLooseLootFlag();
                 Logger.LogInfo("RAID_REVIEW :::: INFO :::: RAID Information Populated");
 
                 if (RAID_REVIEW.RecordingNotification.Value && RAID_REVIEW.WebSocketConnected)

--- a/Client/patches/player_onItemAddedOrRemovedPatch.cs
+++ b/Client/patches/player_onItemAddedOrRemovedPatch.cs
@@ -1,14 +1,19 @@
-﻿using SPT.Reflection.Patching;
+using SPT.Reflection.Patching;
 using EFT.InventoryLogic;
 using EFT;
 using Newtonsoft.Json;
 using System.Reflection;
 using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
 
 namespace RAID_REVIEW
 {
     public class RAID_REVIEW_Player_OnItemAddedOrRemovedPatch : ModulePatch
     {
+        // Buffer removes briefly to detect internal inventory moves (remove+add of same item)
+        private static readonly ConcurrentDictionary<string, TrackingLootItem> _pendingRemoves = new ConcurrentDictionary<string, TrackingLootItem>();
+
         protected override MethodBase GetTargetMethod()
         {
             return typeof(Player).GetMethod("OnItemAddedOrRemoved", BindingFlags.Instance | BindingFlags.Public);
@@ -24,7 +29,7 @@ namespace RAID_REVIEW
                 bool isPackingMagazine = location.Container.ID == "cartridges";
                 if (RAID_REVIEW.LootTracking.Value && !isPackingMagazine)
                 {
-                    TrackingLootItem newLootItem = new TrackingLootItem
+                    var lootItem = new TrackingLootItem
                     {
                         sessionId = RAID_REVIEW.sessionId,
                         profileId = __instance.ProfileId,
@@ -36,10 +41,28 @@ namespace RAID_REVIEW
                         added = added
                     };
 
-                    Telemetry.Send("LOOT", JsonConvert.SerializeObject(newLootItem));
+                    if (!added)
+                    {
+                        // Buffer the remove — if a matching add comes within 50ms, it's an internal move
+                        _pendingRemoves[item.Id] = lootItem;
+                        Task.Delay(50).ContinueWith(_ =>
+                        {
+                            if (_pendingRemoves.TryRemove(item.Id, out var pending))
+                            {
+                                Telemetry.Send("LOOT", JsonConvert.SerializeObject(pending));
+                            }
+                        });
+                    }
+                    else
+                    {
+                        // If there's a pending remove for this item, it's an internal move — skip both
+                        if (_pendingRemoves.TryRemove(item.Id, out _))
+                            return;
+
+                        Telemetry.Send("LOOT", JsonConvert.SerializeObject(lootItem));
+                    }
                 }
             }
-
             catch (Exception ex)
             {
                 Logger.LogError($"{ex.Message}");

--- a/Client/patches/player_onItemAddedOrRemovedPatch.cs
+++ b/Client/patches/player_onItemAddedOrRemovedPatch.cs
@@ -29,16 +29,22 @@ namespace RAID_REVIEW
                 bool isPackingMagazine = location.Container.ID == "cartridges";
                 if (RAID_REVIEW.LootTracking.Value && !isPackingMagazine)
                 {
+                    var pos = __instance.Position;
                     var lootItem = new TrackingLootItem
                     {
                         sessionId = RAID_REVIEW.sessionId,
                         profileId = __instance.ProfileId,
                         time = RAID_REVIEW.stopwatch.ElapsedMilliseconds,
                         itemId = item.Id,
+                        templateId = item.TemplateId.ToString(),
                         itemName = item.LocalizedShortName(),
+                        price = RAID_REVIEW.GetHandbookPrice(item),
                         qty = item.StackObjectsCount,
                         type = item.QuestItem ? "QUEST_ITEM" : "LOOT",
-                        added = added
+                        added = added,
+                        x = pos.x,
+                        y = pos.y,
+                        z = pos.z
                     };
 
                     if (!added)

--- a/Private/src/api/api.tsx
+++ b/Private/src/api/api.tsx
@@ -152,6 +152,15 @@ const api = {
         } catch (error) {
             return heatmapData;
         }
+    },
+
+    getRaidLooseLoot : async function(raidId: string) : Promise<any[]> {
+        try {
+            const response = await fetch(hostname + `/api/raids/${raidId}/loose_loot`);
+            return await response.json();
+        } catch (error) {
+            return [];
+        }
     }
 }
 

--- a/Private/src/component/Map.css
+++ b/Private/src/component/Map.css
@@ -1,7 +1,7 @@
 /* Parent Grid Layout */
 .parent {
   display: grid;
-  grid-template-columns: 400px repeat(3, 1fr);
+  grid-template-columns: 380px 1fr 300px;
   grid-template-rows: auto repeat(3, 1fr) auto;
   grid-column-gap: 0px;
   grid-row-gap: 0px;
@@ -12,20 +12,24 @@
 
 /* Grid Areas */
 .top {
-  grid-area: 1 / 1 / 2 / 5;
+  grid-area: 1 / 1 / 2 / 4;
 }
 .sidebar {
   grid-area: 2 / 1 / 6 / 2;
   z-index: 500;
 }
+.sidebar-right {
+  grid-area: 2 / 3 / 6 / 4;
+  z-index: 500;
+}
 .timeline {
-  grid-area: 5 / 2 / 6 / 5;
+  grid-area: 5 / 2 / 6 / 3;
   z-index: 500;
 }
 .map {
-  grid-area: 2 / 2 / 6 / 5;
-  height: 100vh;
-  width: 100vw;
+  grid-area: 2 / 2 / 6 / 3;
+  height: 100%;
+  width: 100%;
 }
 
 /* Leaflet Map Styling */
@@ -54,6 +58,7 @@
 
 /* Map Wrapper */
 .map-wrapper {
+  position: relative;
   width: 100%;
   height: 100%;
 }
@@ -326,8 +331,8 @@ aside {
   height: fit-content;
   width: fit-content;
   padding: 8px;
-  z-index: 9999;
-  right: 50px;
+  z-index: 499;
+  right: 10px;
   top: 65px;
   gap: 8px;
 }

--- a/Private/src/component/Map.css
+++ b/Private/src/component/Map.css
@@ -225,6 +225,20 @@
   height: 30px;
 }
 
+/* Own-death ring: red pulsing border around the skull for the hovered player's death */
+.own-death-ring {
+  display: inline-block;
+  border: 2px solid #EF4444;
+  border-radius: 50%;
+  padding: 3px;
+  background: rgba(239, 68, 68, 0.2);
+  box-shadow: 0 0 8px 2px rgba(239, 68, 68, 0.5);
+  line-height: 0;
+}
+.own-death-ring img {
+  height: 26px;
+}
+
 /* Kill Stream */
 .kill-stream {
   position: absolute;

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -713,10 +713,11 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                             }
                         }
                         behaviorCat = getBehaviorCategory(currentDecision)
-                        behaviorLine = behaviorCat ? `<br/><span style="color:${behaviorCat.color}">${behaviorCat.label}</span>: ${formatDecisionLabel(currentDecision)}` : ''
+                        behaviorLine = `<br/><span style="color:${behaviorCat.color}">${behaviorCat.label}</span>${currentDecision ? ': ' + formatDecisionLabel(currentDecision) : ''}`
                     }
                     const tip = `${getDisplayName(player)} (${getPlayerDifficultyAndBrain(player)})${behaviorLine}`
-                    const marker = createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, markerOpacity, pmcIndexMap[playerId], tip, behaviorCat?.color)
+                    const ringColor = behaviorCat && behaviorCat.key !== 'idle' && behaviorCat.key !== 'patrol' ? behaviorCat.color : undefined
+                    const marker = createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, markerOpacity, pmcIndexMap[playerId], tip, ringColor)
                     marker._rr_playerId = playerId
                     marker._rr_isDead = false
                     marker._rr_normalOpacity = 1

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -133,6 +133,17 @@ function getMarkerLabel(player: any): string | null {
     return null
 }
 
+function getTooltipIconHtml(player: any, color: string, pmcIdx?: number): string {
+    const label = getMarkerLabel(player)
+    if (label && label !== 'BTR_ICON') {
+        return `<span style="display:inline-block;width:12px;height:12px;border-radius:2px;background:${color};text-align:center;font-size:7px;font-weight:bold;color:#fff;line-height:12px;vertical-align:middle;margin-right:3px;">${label}</span>`
+    }
+    if (pmcIdx !== undefined) {
+        return `<span style="display:inline-block;width:12px;height:12px;border-radius:50%;background:${color};text-align:center;font-size:7px;font-weight:bold;color:#fff;line-height:12px;vertical-align:middle;margin-right:3px;border:1px solid rgba(255,255,255,0.6);">${pmcIdx}</span>`
+    }
+    return `<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${color};vertical-align:middle;margin-right:3px;"></span>`
+}
+
 function createPlayerMarker(latlng: any, color: string, player: any, proportionalScale: number, opacity: number = 1, pmcIndex?: number, tooltipText?: string): L.Layer {
     const displayName = tooltipText || getDisplayName(player)
     const tooltipOpts: L.TooltipOptions = { direction: 'top', offset: [0, -10], className: 'player-tooltip' }
@@ -373,7 +384,32 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
     }, [raidData.players])
 
     const focusItem = useRef(searchParams.get('q') ? searchParams.get('q').split(',') : [])
+    const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const playerFocusRef = useRef<string | null>(null)
+    const focusVictimIdsRef = useRef<Set<string>>(new Set())
+    const focusKillerIdRef = useRef<string | null>(null)
+    const focusLayersRef = useRef<L.Layer[]>([])
     const mapViewRef = useRef({})
+
+    // Kill relationship sets for legend highlighting + refs for position renderer
+    const { focusVictimIds, focusKillerId } = useMemo(() => {
+        const victimIds = new Set<string>()
+        let killerId: string | null = null
+        if (playerFocus && raidData?.kills) {
+            for (const e of raidData.kills) {
+                if (e.time >= timeEndLimit) continue
+                if (e.profileId === playerFocus && e.profileId !== e.killedId) {
+                    victimIds.add(e.killedId)
+                }
+                if (e.killedId === playerFocus) {
+                    killerId = e.profileId
+                }
+            }
+        }
+        focusVictimIdsRef.current = victimIds
+        focusKillerIdRef.current = killerId
+        return { focusVictimIds: victimIds, focusKillerId: killerId }
+    }, [playerFocus, raidData?.kills, timeEndLimit])
 
     const ref = useRef()
     const mapRef = useRef(null)
@@ -468,6 +504,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                     killedNickname: killedNickname ? intl(killedNickname.name, intl_dir) : 'Unknown',
                     weapon: kill.weapon,
                     distance: Number(kill.distance),
+                    bodyPart: kill.bodyPart,
                     source: JSON.parse(kill.positionKiller),
                     target: JSON.parse(kill.positionKilled),
                 })
@@ -732,70 +769,73 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
             if (MAP && !hidePlayers && cleanPositions.length > 0) {
                 let endOfLine = cleanPositions[cleanPositions.length - 1]
 
-                // Focused Player
-                if (playerFocus !== null && playerFocus === playerId) {
-
-                    if (!MAP) return
-                    L.polyline(cleanPositions, { color: pickedColor, weight: 4, opacity: 1 })
-                        .addTo(MAP)
-                        .on('click', () => {
-                            setFollowPlayer(playerId)
-                            setFollowPlayerZoomed(false)
-                        })
-                    const tip = `${getDisplayName(player)} (${getPlayerDifficultyAndBrain(player)})`
-                    const marker = createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, 1, pmcIndexMap[playerId], tip)
-                        .on('click', () => {
-                            setFollowPlayer(playerId)
-                            setFollowPlayerZoomed(false)
-                        })
-                    deferredMarkers.push({ layer: marker, playerId })
-                } else {
-                    let focusedOpacityPolyLine = preserveHistory ? 0.1 : isPlayerDead ? 0 : 0.1
-                    let focusedOpacityCircle = isPlayerDead ? 0 : 0.1
-
-                    if (!MAP) return
-                    L.polyline(cleanPositions, { color: pickedColor, weight: 4, opacity: focusedOpacityPolyLine })
-                        .addTo(MAP)
-                        .on('click', () => {
-                            setFollowPlayer(playerId)
-                            setFollowPlayerZoomed(false)
-                        })
-                    if (!isPlayerDead) {
-                        const tip = `${getDisplayName(player)} (${getPlayerDifficultyAndBrain(player)})`
-                        deferredMarkers.push({ layer: createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, focusedOpacityCircle, pmcIndexMap[playerId], tip), playerId, followAction: followPlayer === playerId })
+                // Determine opacity based on current focus (read from refs to avoid re-render dependency)
+                const currentFocus = playerFocusRef.current
+                const currentVictimIds = focusVictimIdsRef.current
+                const currentKillerId = focusKillerIdRef.current
+                let polylineOpacity: number
+                let markerOpacity: number
+                if (currentFocus !== null) {
+                    if (currentFocus === playerId) {
+                        polylineOpacity = 1
+                        markerOpacity = 1
+                    } else if (currentVictimIds.has(playerId)) {
+                        // Victim of focused player: hide trail (dead, no dot rendered)
+                        polylineOpacity = 0
+                        markerOpacity = 0
+                    } else if (currentKillerId && currentKillerId === playerId) {
+                        // Killer of focused player: keep visible
+                        polylineOpacity = 0.6
+                        markerOpacity = 0.8
+                    } else {
+                        polylineOpacity = isPlayerDead ? 0 : 0.1
+                        markerOpacity = isPlayerDead ? 0 : 0.1
                     }
+                } else {
+                    polylineOpacity = preserveHistory ? 0.8 : isPlayerDead ? 0 : 0.8
+                    markerOpacity = isPlayerDead ? 0 : 1
                 }
 
-                // Normal rendering
-                if (playerFocus === null) {
-                    let focusedOpacityPolyLine = preserveHistory ? 0.8 : isPlayerDead ? 0 : 0.8
-                    L.polyline(cleanPositions, { color: pickedColor, weight: 4, opacity: focusedOpacityPolyLine })
-                        .addTo(MAP)
-                        .on('click', () => {
-                            setFollowPlayer(playerId)
-                            setFollowPlayerZoomed(false)
-                        })
-                    if (!isPlayerDead) {
-                        const tip = `${getDisplayName(player)} (${getPlayerDifficultyAndBrain(player)})`
-                        deferredMarkers.push({ layer: createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, 1, pmcIndexMap[playerId], tip), playerId })
-                        if (followPlayer === playerId) {
-                            if (!followPlayerZoomed) {
-                                MAP.setZoom(3)
-                                setFollowPlayerZoomed(true)
-                            }
-                            MAP.panTo(endOfLine, 4)
+                if (!MAP) return
+                const pl = L.polyline(cleanPositions, { color: pickedColor, weight: 4, opacity: polylineOpacity })
+                    .addTo(MAP)
+                    .on('click', () => {
+                        setFollowPlayer(playerId)
+                        setFollowPlayerZoomed(false)
+                    })
+                pl._rr_playerId = playerId
+                pl._rr_isDead = !!isPlayerDead
+                pl._rr_normalOpacity = preserveHistory ? 0.8 : isPlayerDead ? 0 : 0.8
+
+                if (!isPlayerDead) {
+                    const tip = `${getDisplayName(player)} (${getPlayerDifficultyAndBrain(player)})`
+                    const marker = createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, markerOpacity, pmcIndexMap[playerId], tip)
+                    marker._rr_playerId = playerId
+                    marker._rr_isDead = false
+                    marker._rr_normalOpacity = 1
+                    deferredMarkers.push({ layer: marker, playerId })
+                    if (followPlayer === playerId) {
+                        if (!followPlayerZoomed) {
+                            MAP.setZoom(3)
+                            setFollowPlayerZoomed(true)
                         }
+                        MAP.panTo(endOfLine, 4)
                     }
                 }
             }
         }
 
         // Second pass: add all markers on top of polylines
-        for (const { layer, playerId, followAction } of deferredMarkers) {
+        for (const { layer, playerId } of deferredMarkers) {
             layer.addTo(MAP)
-            if (followAction) {
-                MAP.panTo((layer as any).getLatLng?.() || (layer as any)._latlng, 4)
-            }
+            layer.on('mouseover', () => {
+                if (focusTimeoutRef.current) clearTimeout(focusTimeoutRef.current)
+                setPlayerFocus(playerId)
+            })
+            layer.on('mouseout', () => {
+                if (focusTimeoutRef.current) clearTimeout(focusTimeoutRef.current)
+                focusTimeoutRef.current = setTimeout(() => setPlayerFocus(null), 100)
+            })
         }
 
         if (sliderTimes.length === 0) {
@@ -808,7 +848,173 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
             setTimeEndLimit(times[times.length - 1])
             setTimeCurrentIndex(times.length - 1)
         }
-    }, [mapIsReady, mapViewRef, timeEndLimit, timeStartLimit, timeCurrentIndex, MAP, preserveHistory, events, hideEvents, hidePlayers, followPlayer, playerFocus, pmcIndexMap])
+    }, [mapIsReady, mapViewRef, timeEndLimit, timeStartLimit, timeCurrentIndex, MAP, preserveHistory, events, hideEvents, hidePlayers, followPlayer, pmcIndexMap])
+
+    // Focus overlay: adjusts layer opacity + kill visualization without full re-render
+    useEffect(() => {
+        if (!MAP || !mapIsReady) return
+        playerFocusRef.current = playerFocus
+
+        // Clean up previous focus layers
+        for (const layer of focusLayersRef.current) {
+            MAP.removeLayer(layer)
+        }
+        focusLayersRef.current = []
+
+        // Build victim/killer sets for kill relationship highlighting
+        const victimIds = new Set<string>()
+        let killerId: string | null = null
+        if (playerFocus) {
+            for (const e of events) {
+                if (e.time >= timeEndLimit) continue
+                if (e.profileId === playerFocus && e.profileId !== e.killedId) {
+                    victimIds.add(e.killedId)
+                }
+                if (e.killedId === playerFocus) {
+                    killerId = e.profileId
+                }
+            }
+        }
+
+        // Adjust opacity of all tagged player layers
+        for (const key in MAP._layers) {
+            const layer = MAP._layers[key]
+            if (!layer._rr_playerId) continue
+
+            if (playerFocus === null) {
+                // Restore normal opacity
+                if (layer instanceof L.Polyline && !(layer instanceof L.Circle)) {
+                    layer.setStyle({ opacity: layer._rr_normalOpacity ?? 0.8 })
+                } else if (layer instanceof L.Circle) {
+                    const op = layer._rr_normalOpacity ?? 1
+                    layer.setStyle({ opacity: op, fillOpacity: op })
+                }
+                if (layer instanceof L.Marker) {
+                    layer.setOpacity(layer._rr_normalOpacity ?? 1)
+                }
+            } else if (playerFocus === layer._rr_playerId) {
+                // Full opacity for focused player
+                if (layer instanceof L.Polyline && !(layer instanceof L.Circle)) {
+                    layer.setStyle({ opacity: 1 })
+                } else if (layer instanceof L.Circle) {
+                    layer.setStyle({ opacity: 1, fillOpacity: 1 })
+                }
+                if (layer instanceof L.Marker) {
+                    layer.setOpacity(1)
+                }
+            } else {
+                // Determine opacity: victims hidden, killer visible, others dimmed
+                const op = victimIds.has(layer._rr_playerId) ? 0
+                    : (killerId && killerId === layer._rr_playerId) ? 0.7
+                    : layer._rr_isDead ? 0 : 0.1
+                if (layer instanceof L.Polyline && !(layer instanceof L.Circle)) {
+                    layer.setStyle({ opacity: op })
+                } else if (layer instanceof L.Circle) {
+                    layer.setStyle({ opacity: op, fillOpacity: op })
+                }
+                if (layer instanceof L.Marker) {
+                    layer.setOpacity(op)
+                }
+            }
+        }
+
+        // Restore any previously modified tooltips, then enrich focused player's dot tooltip
+        for (const key in MAP._layers) {
+            const layer = MAP._layers[key]
+            if (layer._rr_originalTooltip !== undefined) {
+                layer.setTooltipContent(layer._rr_originalTooltip)
+                layer.closeTooltip()
+                delete layer._rr_originalTooltip
+            }
+        }
+        if (playerFocus) {
+            const kills = events.filter(e => e.profileId === playerFocus && e.profileId !== e.killedId && e.time < timeEndLimit)
+            const death = events.find(e => e.killedId === playerFocus && e.time < timeEndLimit)
+
+            // Build killfeed HTML with icons
+            const buildFeedHtml = (titleHtml: string) => {
+                let html = `<strong>${titleHtml}</strong>`
+                if (kills.length > 0 || death) {
+                    html += '<div style="margin-top:4px;border-top:1px solid rgba(255,255,255,0.2);padding-top:4px;font-size:11px;">'
+                    for (const k of kills) {
+                        const victim = raidData.players.find(p => p.profileId === k.killedId)
+                        const victimIdx = victim ? raidData.players.indexOf(victim) : 0
+                        const victimIcon = victim ? getTooltipIconHtml(victim, getPlayerColor(victim, victimIdx), pmcIndexMap[k.killedId]) : ''
+                        html += `<div>\u2620 ${victimIcon}${k.killedNickname} (${intl([k.weapon.replace('Name', 'ShortName')], intl_dir)}, ${k.distance.toFixed(0)}m${k.bodyPart ? ', ' + k.bodyPart : ''})</div>`
+                    }
+                    if (death) {
+                        const killer = raidData.players.find(p => p.profileId === death.profileId)
+                        const killerIdx = killer ? raidData.players.indexOf(killer) : 0
+                        const killerIcon = killer ? getTooltipIconHtml(killer, getPlayerColor(killer, killerIdx), pmcIndexMap[death.profileId]) : ''
+                        html += `<div style="color:#EF4444;">\u{1F480} ${killerIcon}${death.profileNickname} (${intl([death.weapon.replace('Name', 'ShortName')], intl_dir)}, ${death.distance.toFixed(0)}m${death.bodyPart ? ', ' + death.bodyPart : ''})</div>`
+                    }
+                    html += '</div>'
+                }
+                return html
+            }
+
+            // Try to find existing marker for this player (alive players)
+            let found = false
+            for (const key in MAP._layers) {
+                const layer = MAP._layers[key]
+                if (layer._rr_playerId === playerFocus && (layer instanceof L.Marker || layer instanceof L.Circle)) {
+                    const tooltip = layer.getTooltip()
+                    if (tooltip) {
+                        layer._rr_originalTooltip = tooltip.getContent()
+                        layer.setTooltipContent(buildFeedHtml(layer._rr_originalTooltip))
+                        layer.openTooltip()
+                    }
+                    found = true
+                    break
+                }
+            }
+
+            // Dead player: no marker on map, create a temporary one at death position
+            if (!found && death) {
+                const player = raidData.players.find(p => p.profileId === playerFocus)
+                const playerIdx = player ? raidData.players.indexOf(player) : 0
+                const color = player ? getPlayerColor(player, playerIdx) : '#999'
+                const displayName = player ? `${getDisplayName(player)} (${getPlayerDifficultyAndBrain(player)})` : 'Unknown'
+                const tmpMarker = L.circleMarker([death.target.z, death.target.x], {
+                    radius: 6, color, fillColor: color, fillOpacity: 0.8, weight: 1, interactive: false
+                }).addTo(MAP)
+                tmpMarker.bindTooltip(buildFeedHtml(displayName), { direction: 'top', offset: [0, -10], className: 'player-tooltip' })
+                tmpMarker.openTooltip()
+                focusLayersRef.current.push(tmpMarker)
+            }
+        }
+
+        // Add kill visualization if a player is focused
+        if (playerFocus && events.length > 0) {
+            // Kills made by hovered player (respecting timeline)
+            const playerKills = events.filter(e => e.profileId === playerFocus && e.profileId !== e.killedId && e.time < timeEndLimit)
+            for (const kill of playerKills) {
+                const line = L.polyline(
+                    [[kill.source.z, kill.source.x], [kill.target.z, kill.target.x]],
+                    { color: 'red', weight: 2, dashArray: [10], dashOffset: 3, opacity: 1, interactive: false }
+                ).addTo(MAP)
+                focusLayersRef.current.push(line)
+                const skullHtml = `<img src="/skull.png" /><span class="tooltiptext event event-map text-sm"><strong>${kill.killedNickname}</strong><br/>${intl([kill.weapon.replace('Name', 'ShortName')], intl_dir)}, ${kill.distance.toFixed(0)}m${kill.bodyPart ? ', ' + kill.bodyPart : ''}</span>`
+                const skullIcon = L.divIcon({ className: 'death-icon tooltip event follow-kill-marker', html: skullHtml })
+                const marker = L.marker([kill.target.z, kill.target.x], { icon: skullIcon, interactive: false, zIndexOffset: -1000 }).addTo(MAP)
+                focusLayersRef.current.push(marker)
+            }
+
+            // Death of the hovered player (if dead) — distinct red-ringed skull
+            const deathEvent = events.find(e => e.killedId === playerFocus && e.time < timeEndLimit)
+            if (deathEvent) {
+                const line = L.polyline(
+                    [[deathEvent.source.z, deathEvent.source.x], [deathEvent.target.z, deathEvent.target.x]],
+                    { color: 'red', weight: 2, dashArray: [10], dashOffset: 3, opacity: 1, interactive: false }
+                ).addTo(MAP)
+                focusLayersRef.current.push(line)
+                const ownDeathHtml = `<div class="own-death-ring"><img src="/skull.png" /></div><span class="tooltiptext event event-map text-sm"><strong>${deathEvent.profileNickname}</strong><br/>killed<br/><strong>${deathEvent.killedNickname}</strong><br/>${intl([deathEvent.weapon.replace('Name', 'ShortName')], intl_dir)}, ${deathEvent.distance.toFixed(0)}m${deathEvent.bodyPart ? ', ' + deathEvent.bodyPart : ''}</span>`
+                const ownDeathIcon = L.divIcon({ className: 'death-icon tooltip event follow-kill-marker', html: ownDeathHtml })
+                const marker = L.marker([deathEvent.target.z, deathEvent.target.x], { icon: ownDeathIcon, interactive: false, zIndexOffset: -1000 }).addTo(MAP)
+                focusLayersRef.current.push(marker)
+            }
+        }
+    }, [playerFocus, MAP, mapIsReady, events, timeEndLimit, intl_dir])
 
     // Slider Time Update
     useEffect(() => {
@@ -998,7 +1204,8 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
         
             // Remove polylines without eventType or not being ballisticsLine, circles, and special bot markers
             const isSpecialBotMarker = layer instanceof L.Marker && layer.options?.icon?.options?.className === 'special-bot-marker';
-            if ((layer instanceof L.Polyline && (!layer.eventType || layer.eventType !== 'ballisticsLine')) || layer instanceof L.Circle || isSpecialBotMarker) {
+            const isFollowKillMarker = layer instanceof L.Marker && layer.options?.icon?.options?.className?.includes('follow-kill-marker');
+            if ((layer instanceof L.Polyline && (!layer.eventType || layer.eventType !== 'ballisticsLine')) || layer instanceof L.Circle || isSpecialBotMarker || isFollowKillMarker) {
                 m.removeLayer(layer);
                 continue;
             }
@@ -1252,7 +1459,8 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                                                                 <li
                                                                     className="flex items-center justify-between player-legend-item px-2"
                                                                     key={player.profileId}
-                                                                    onMouseEnter={() => setPlayerFocus(player.profileId)}
+                                                                    style={focusVictimIds.has(player.profileId) ? { borderLeft: '3px solid #22C55E', background: 'rgba(34,197,94,0.12)' } : focusKillerId === player.profileId ? { borderLeft: '3px solid #EF4444', background: 'rgba(239,68,68,0.12)' } : undefined}
+                                                                    onMouseEnter={() => { if (focusTimeoutRef.current) clearTimeout(focusTimeoutRef.current); setPlayerFocus(player.profileId) }}
                                                                     onMouseLeave={() => setPlayerFocus(null)}
                                                                     onClick={() => {
                                                                         setFollowPlayer(followPlayer === player.profileId ? null : player.profileId)
@@ -1312,7 +1520,8 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                                                                 <li
                                                                     className="flex items-center justify-between player-legend-item px-2"
                                                                     key={player.profileId}
-                                                                    onMouseEnter={() => setPlayerFocus(player.profileId)}
+                                                                    style={focusVictimIds.has(player.profileId) ? { borderLeft: '3px solid #22C55E', background: 'rgba(34,197,94,0.12)' } : focusKillerId === player.profileId ? { borderLeft: '3px solid #EF4444', background: 'rgba(239,68,68,0.12)' } : undefined}
+                                                                    onMouseEnter={() => { if (focusTimeoutRef.current) clearTimeout(focusTimeoutRef.current); setPlayerFocus(player.profileId) }}
                                                                     onMouseLeave={() => setPlayerFocus(null)}
                                                                     onClick={() => {
                                                                         setFollowPlayer(followPlayer === player.profileId ? null : player.profileId)
@@ -1355,7 +1564,8 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                                                     <li
                                                         className="flex items-center justify-between player-legend-item px-2"
                                                         key={player.profileId}
-                                                        onMouseEnter={() => setPlayerFocus(player.profileId)}
+                                                        style={focusVictimIds.has(player.profileId) ? { borderLeft: '3px solid #22C55E', background: 'rgba(34,197,94,0.12)' } : focusKillerId === player.profileId ? { borderLeft: '3px solid #EF4444', background: 'rgba(239,68,68,0.12)' } : undefined}
+                                                        onMouseEnter={() => { if (focusTimeoutRef.current) clearTimeout(focusTimeoutRef.current); setPlayerFocus(player.profileId) }}
                                                         onMouseLeave={() => setPlayerFocus(null)}
                                                         onClick={() => {
                                                             setFollowPlayer(followPlayer === player.profileId ? null : player.profileId)
@@ -1416,7 +1626,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                                         >
                                             VIEW
                                         </a>
-                                        ] {(() => { const p = raidData.players.find(p => p.profileId === e.profileId); const idx = p ? raidData.players.indexOf(p) : 0; return p ? getLegendIcon(p, getPlayerColor(p, idx), pmcIndexMap[p.profileId]) : null })()}<strong>{e.profileNickname}</strong> killed {(() => { const p = raidData.players.find(p => p.profileId === e.killedId); const idx = p ? raidData.players.indexOf(p) : 0; return p ? getLegendIcon(p, getPlayerColor(p, idx), pmcIndexMap[p.profileId]) : null })()}<strong>{e.killedNickname}</strong> ({intl([e.weapon.replace('Name', 'ShortName')], intl_dir)} - {e.distance.toFixed(0)}m)
+                                        ] {(() => { const p = raidData.players.find(p => p.profileId === e.profileId); const idx = p ? raidData.players.indexOf(p) : 0; return p ? getLegendIcon(p, getPlayerColor(p, idx), pmcIndexMap[p.profileId]) : null })()}<strong>{e.profileNickname}</strong> killed {(() => { const p = raidData.players.find(p => p.profileId === e.killedId); const idx = p ? raidData.players.indexOf(p) : 0; return p ? getLegendIcon(p, getPlayerColor(p, idx), pmcIndexMap[p.profileId]) : null })()}<strong>{e.killedNickname}</strong> ({intl([e.weapon.replace('Name', 'ShortName')], intl_dir)} - {e.distance.toFixed(0)}m, {e.bodyPart})
                                     </span>
                                 </div>
                             ))}

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -12,7 +12,7 @@ import api from '../api/api.js';
 import { msToHMS, intl } from '../helpers/index.js';
 import { calculateNewPosition, findInsertIndex } from '../modules/utils.js'
 import { useMapImages } from '../modules/maps-index.js';
-import { TrackingPositionalData } from '../types/api_types.js';
+import { TrackingPositionalData, TrackingLooseLootItem, TrackingPlayerInventoryItem } from '../types/api_types.js';
 import { PlayerSlider } from './MapPlayerSlider.js';
 
 import BotMapping from '../assets/botMapping.json'
@@ -82,6 +82,20 @@ function getTooltipIconHtml(player: any, color: string, pmcIdx?: number): string
         return `<span style="display:inline-block;width:12px;height:12px;border-radius:50%;background:${color};text-align:center;font-size:7px;font-weight:bold;color:#fff;line-height:12px;vertical-align:middle;margin-right:3px;border:1px solid rgba(255,255,255,0.6);">${pmcIdx}</span>`
     }
     return `<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${color};vertical-align:middle;margin-right:3px;"></span>`
+}
+
+function formatCompactNumber(value: number): string {
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+    if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K`
+    return String(value)
+}
+
+function getLootPriceColor(totalPrice: number): string {
+    if (totalPrice >= 500_000) return '#FFD700'  // gold
+    if (totalPrice >= 100_000) return '#A855F7'  // purple
+    if (totalPrice >= 50_000) return '#3B82F6'   // blue
+    if (totalPrice >= 10_000) return '#94A3B8'   // light slate (brighter than old gray)
+    return '#64748B'                              // slate
 }
 
 function createPlayerMarker(latlng: any, color: string, player: any, proportionalScale: number, opacity: number = 1, pmcIndex?: number, tooltipText?: string, behaviorColor?: string | null): L.Layer {
@@ -265,6 +279,53 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
     const [hideBallistics, setHideBallistics] = useState(false)
     const [hideNerdStats, setHideNerdStats] = useState(true)
     const [preserveHistory, setPreserveHistory] = useState(false)
+
+    // Loose Loot
+    const [showLooseLoot, setShowLooseLoot] = useState(true)
+    const [looseLootMinPrice, setLooseLootMinPrice] = useState<number>(() => {
+        const saved = localStorage.getItem('rr_looseLoot_minPrice')
+        return saved ? Number(saved) : 50000
+    })
+    const [looseLootFilter, setLooseLootFilter] = useState<'all' | 'ground' | 'container'>(() => {
+        const saved = localStorage.getItem('rr_looseLoot_filter')
+        return (saved === 'ground' || saved === 'container') ? saved : 'all'
+    })
+    const [looseLootData, setLooseLootData] = useState<TrackingLooseLootItem[]>([])
+    const [looseLootCollapsed, setLooseLootCollapsed] = useState(true)
+    const looseLootLayerRef = useRef<L.LayerGroup | null>(null)
+    const looseLootHighlightRef = useRef<L.CircleMarker | null>(null)
+
+    // Bot Inventory
+    const [botInvCollapsed, setBotInvCollapsed] = useState(true)
+    const [selectedBotProfileId, setSelectedBotProfileId] = useState<string>('')
+    const [collapsedSlots, setCollapsedSlots] = useState<Record<string, boolean>>({})
+    const toggleSlotCollapse = (slot: string) => setCollapsedSlots(prev => ({ ...prev, [slot]: !prev[slot] }))
+
+    const highlightLooseLootItem = useCallback((item: TrackingLooseLootItem | null) => {
+        if (looseLootHighlightRef.current && MAP) {
+            MAP.removeLayer(looseLootHighlightRef.current)
+            looseLootHighlightRef.current = null
+        }
+        if (!item || !MAP) return
+        const tp = item.price * item.qty
+        const color = getLootPriceColor(tp)
+        const isC = item.inContainer === true || item.inContainer === 1
+        const ring = L.circleMarker([item.z, item.x], {
+            radius: 14,
+            color: '#fff',
+            weight: 2,
+            fillColor: color,
+            fillOpacity: 0.4,
+            interactive: false,
+        })
+        ring.bindTooltip(
+            `<span style="color:${color}">${isC ? '\u25A0' : '\u25C6'}</span> ${item.itemName}${item.qty > 1 ? ' x' + item.qty : ''} \u2014 \u20BD${tp.toLocaleString()}`,
+            { direction: 'top', offset: [0, -14], className: 'player-tooltip player-tooltip-html', permanent: true }
+        )
+        ring.addTo(MAP)
+        ring.openTooltip()
+        looseLootHighlightRef.current = ring
+    }, [MAP])
 
     // Events
     const [events, setEvents] = useState([])
@@ -1104,6 +1165,388 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
         return () => clearInterval(interval)
     }, [playing, sliderTimes, playbackSpeed, timeCurrentIndex, preserveHistory])
 
+    // Loose Loot: fetch data lazily when toggled on
+    useEffect(() => {
+        if (!showLooseLoot) return
+        if (looseLootData.length > 0) return // already cached
+        ;(async () => {
+            const data = await api.getRaidLooseLoot(raidId)
+            if (data && data.length > 0) {
+                setLooseLootData(data as TrackingLooseLootItem[])
+            }
+        })()
+    }, [showLooseLoot, raidId])
+
+    // Loose Loot: persist settings to localStorage
+    useEffect(() => {
+        localStorage.setItem('rr_looseLoot_minPrice', String(looseLootMinPrice))
+    }, [looseLootMinPrice])
+    useEffect(() => {
+        localStorage.setItem('rr_looseLoot_filter', looseLootFilter)
+    }, [looseLootFilter])
+
+    // Build set of picked-up item IDs before current timeline position
+    const pickedUpItemIds = useMemo(() => {
+        const ids = new Set<string>()
+        if (!raidData?.looting) return ids
+        for (const loot of raidData.looting) {
+            const added = loot.added === 'True' || loot.added === 'true' || loot.added === '1'
+            if (added && Number(loot.time) <= timeEndLimit) {
+                const iid = loot.itemId || loot.id
+                if (iid) ids.add(iid)
+            }
+        }
+        return ids
+    }, [raidData?.looting, timeEndLimit])
+
+    // Loose Loot: render / update markers on map (timeline-aware + container grouping)
+    useEffect(() => {
+        if (!MAP || !mapIsReady) return
+
+        // Remove old layer group
+        if (looseLootLayerRef.current) {
+            MAP.removeLayer(looseLootLayerRef.current)
+            looseLootLayerRef.current = null
+        }
+
+        if (!showLooseLoot || looseLootData.length === 0) return
+
+        const group = L.layerGroup()
+
+        // Separate ground items and container items
+        const groundItems: TrackingLooseLootItem[] = []
+        const containerGroups: Record<string, TrackingLooseLootItem[]> = {}
+
+        for (const item of looseLootData) {
+            // Skip items picked up before current time
+            if (item.itemId && pickedUpItemIds.has(item.itemId)) continue
+
+            const totalPrice = item.price * item.qty
+            if (totalPrice < looseLootMinPrice) continue
+
+            const isContainer = item.inContainer === true || item.inContainer === 1
+            if (looseLootFilter === 'ground' && isContainer) continue
+            if (looseLootFilter === 'container' && !isContainer) continue
+
+            if (isContainer) {
+                const key = `${item.x},${item.y},${item.z}`
+                if (!containerGroups[key]) containerGroups[key] = []
+                containerGroups[key].push(item)
+            } else {
+                groundItems.push(item)
+            }
+        }
+
+        // Render ground items as circleMarkers (SVG — much lighter than divIcon DOM elements)
+        for (const item of groundItems) {
+            const totalPrice = item.price * item.qty
+            const color = getLootPriceColor(totalPrice)
+            const marker = L.circleMarker([item.z, item.x], {
+                radius: 4,
+                color: 'rgba(255,255,255,0.7)',
+                weight: 1,
+                fillColor: color,
+                fillOpacity: 0.9,
+                interactive: true,
+            })
+            marker.bindTooltip(
+                `<span style="color:${color}">\u25C6</span> ${item.itemName}${item.qty > 1 ? ' x' + item.qty : ''} \u2014 \u20BD${totalPrice.toLocaleString()}`,
+                { direction: 'top', offset: [0, -8], className: 'player-tooltip player-tooltip-html' }
+            )
+            marker._rr_looseLoot = true
+            group.addLayer(marker)
+        }
+
+        // Render container groups as circleMarkers with tooltip listing contents
+        for (const [, items] of Object.entries(containerGroups)) {
+            const containerTotal = items.reduce((sum, i) => sum + i.price * i.qty, 0)
+            const color = getLootPriceColor(containerTotal)
+            const first = items[0]
+            const cName = first.containerName || 'Container'
+
+            let tooltipHtml = `<span style="color:${color}">\u25A0</span> <strong>${cName}</strong> (${items.length}) \u2014 \u20BD${containerTotal.toLocaleString()}<div style="margin-top:3px;border-top:1px solid rgba(255,255,255,0.2);padding-top:3px;">`
+            for (const item of items.sort((a, b) => (b.price * b.qty) - (a.price * a.qty))) {
+                const tp = item.price * item.qty
+                tooltipHtml += `<div style="font-size:10px;"><span style="color:${getLootPriceColor(tp)}">${item.itemName}</span>${item.qty > 1 ? ' x' + item.qty : ''} \u20BD${tp.toLocaleString()}</div>`
+            }
+            tooltipHtml += '</div>'
+
+            const marker = L.circleMarker([first.z, first.x], {
+                radius: 5,
+                color: color,
+                weight: 1.5,
+                fillColor: color + '44',
+                fillOpacity: 1,
+                interactive: true,
+            })
+            marker.bindTooltip(tooltipHtml, { direction: 'top', offset: [0, -8], className: 'player-tooltip player-tooltip-html' })
+            marker._rr_looseLoot = true
+            group.addLayer(marker)
+        }
+
+        // Render dropped items (from looting events with added=false and position data)
+        if (raidData?.looting && looseLootFilter !== 'container') {
+            // Build set of itemIds that were picked back up before current timeline
+            const rePickedIds = new Set<string>()
+            for (const loot of raidData.looting) {
+                const isAdded = loot.added === 'True' || loot.added === 'true' || loot.added === '1'
+                if (isAdded && Number(loot.time) <= timeEndLimit) {
+                    const iid = loot.itemId || loot.id
+                    if (iid) rePickedIds.add(iid)
+                }
+            }
+
+            for (const loot of raidData.looting) {
+                const added = loot.added === 'True' || loot.added === 'true' || loot.added === '1'
+                if (added) continue
+                if (Number(loot.time) > timeEndLimit) continue
+                // Skip if this item was picked back up before current time
+                const iid = loot.itemId || loot.id
+                if (iid && rePickedIds.has(iid)) continue
+                const lx = Number(loot.x), lz = Number(loot.z)
+                if (!lx && !lz) continue // no position data (old raids)
+                const tp = (Number(loot.price) || 0) * (Number(loot.qty) || 1)
+                if (tp < looseLootMinPrice) continue
+                const color = getLootPriceColor(tp)
+                const marker = L.circleMarker([lz, lx], {
+                    radius: 4,
+                    color: '#fff',
+                    weight: 1,
+                    fillColor: color,
+                    fillOpacity: 0.9,
+                    interactive: true,
+                    dashArray: '3 2',
+                })
+                marker.bindTooltip(
+                    `<span style="color:${color}">\u2B25</span> ${loot.itemName || loot.name}${Number(loot.qty) > 1 ? ' x' + loot.qty : ''} \u2014 \u20BD${tp.toLocaleString()} <span style="opacity:0.5">(dropped)</span>`,
+                    { direction: 'top', offset: [0, -8], className: 'player-tooltip player-tooltip-html' }
+                )
+                marker._rr_looseLoot = true
+                group.addLayer(marker)
+            }
+        }
+
+        group.addTo(MAP)
+        looseLootLayerRef.current = group
+
+        return () => {
+            if (looseLootLayerRef.current && MAP) {
+                MAP.removeLayer(looseLootLayerRef.current)
+                looseLootLayerRef.current = null
+            }
+        }
+    }, [MAP, mapIsReady, showLooseLoot, looseLootData, looseLootMinPrice, looseLootFilter, pickedUpItemIds, raidData?.looting, timeEndLimit])
+
+    // Compute filtered loot stats (timeline-aware)
+    const looseLootStats = useMemo(() => {
+        if (looseLootData.length === 0) return { shown: 0, total: 0, ground: 0, container: 0 }
+        let ground = 0
+        let container = 0
+        let shown = 0
+        for (const item of looseLootData) {
+            if (item.itemId && pickedUpItemIds.has(item.itemId)) continue
+            const isContainer = item.inContainer === true || item.inContainer === 1
+            if (isContainer) container++
+            else ground++
+            const totalPrice = item.price * item.qty
+            if (totalPrice < looseLootMinPrice) continue
+            if (looseLootFilter === 'ground' && isContainer) continue
+            if (looseLootFilter === 'container' && !isContainer) continue
+            shown++
+        }
+        return { shown, total: looseLootData.length, ground, container }
+    }, [looseLootData, looseLootMinPrice, looseLootFilter, pickedUpItemIds])
+
+    // Slots that are not lootable (excluded from value totals)
+    const NON_LOOTABLE_SLOTS = /^(main|SecuredContainer)$/i
+
+    // Compute bot spawn values from player_inventory (exclude non-lootable slots)
+    const botSpawnValues = useMemo(() => {
+        const values: Record<string, number> = {}
+        if (raidData.player_inventory) {
+            for (const item of raidData.player_inventory) {
+                if (NON_LOOTABLE_SLOTS.test(item.slot || '')) continue
+                if (!values[item.profileId]) values[item.profileId] = 0
+                values[item.profileId] += item.price * item.qty
+            }
+        }
+        return values
+    }, [raidData.player_inventory])
+
+    // Bots with inventory data (for inspector dropdown)
+    const botsWithInventory = useMemo(() => {
+        if (!raidData.player_inventory || !raidData.players) return []
+        const profileIds = new Set(raidData.player_inventory.map(i => i.profileId))
+        return raidData.players.filter(p => profileIds.has(p.profileId))
+    }, [raidData.player_inventory, raidData.players])
+
+    // Equipment-level slot display order
+    const EQUIPMENT_SLOT_ORDER = [
+        'FirstPrimaryWeapon', 'SecondPrimaryWeapon', 'Holster', 'Scabbard',
+        'Headwear', 'Earpiece', 'FaceCover', 'ArmorVest', 'TacticalVest',
+        'Pockets', 'Backpack', 'SecuredContainer', 'ArmBand',
+        'SpecialSlot1', 'SpecialSlot2', 'SpecialSlot3',
+    ]
+    const WEAPON_SLOTS = new Set(['FirstPrimaryWeapon', 'SecondPrimaryWeapon', 'Holster', 'Scabbard'])
+
+    // Slot grouping rules: pattern → parent group name
+    const SLOT_GROUP_RULES: { pattern: RegExp; name: string }[] = [
+        { pattern: /^mod_|^cartridges$|^patron_in_weapon$/i, name: '__weapon_att__' },
+        { pattern: /^helmet_/i, name: 'Helmet parts' },
+        { pattern: /^soft_armor_/i, name: 'Soft armor parts' },
+        { pattern: /^heavy_armor_/i, name: 'Heavy armor parts' },
+        { pattern: /_plate$/i, name: 'Armor plates' },
+        { pattern: /^pocket/i, name: '__merge_Pockets__' },  // merge into Pockets equipment slot
+    ]
+    // Slots to completely hide
+    const HIDDEN_SLOT = /^(\d+|[0-9a-f]{20,}|Default Inventory|unknown|camora_|GridView)/i
+
+    // Selected bot inventory: equipment groups + weapon attachments nested under weapons
+    interface InvSubGroup { name: string; items: TrackingPlayerInventoryItem[]; total: number }
+    interface InvSlotGroup { name: string; items: TrackingPlayerInventoryItem[]; total: number; attachments?: InvSubGroup; subGroups?: InvSubGroup[] }
+    const selectedBotInventory = useMemo(() => {
+        if (!selectedBotProfileId || !raidData.player_inventory) return { slots: [] as InvSlotGroup[], total: 0 }
+        const items = raidData.player_inventory.filter(i => i.profileId === selectedBotProfileId)
+
+        const equipmentGroups: Record<string, TrackingPlayerInventoryItem[]> = {}
+        const weaponAttachments: TrackingPlayerInventoryItem[] = []
+        const groupedSlots: Record<string, TrackingPlayerInventoryItem[]> = {}  // helmet_*, soft_armor_*, etc.
+        let total = 0
+
+        for (const item of items) {
+            const slot = item.slot || 'unknown'
+            const val = item.price * item.qty
+            // Exclude non-lootable slots from total
+            if (!NON_LOOTABLE_SLOTS.test(slot)) total += val
+
+            // Hidden slots
+            if (HIDDEN_SLOT.test(slot)) continue
+
+            // Check grouping rules
+            let matched = false
+            for (const rule of SLOT_GROUP_RULES) {
+                if (rule.pattern.test(slot)) {
+                    if (rule.name === '__weapon_att__') {
+                        weaponAttachments.push(item)
+                    } else if (rule.name.startsWith('__merge_') && rule.name.endsWith('__')) {
+                        // Merge directly into the target equipment slot
+                        const targetSlot = rule.name.slice(8, -2) // "__merge_Pockets__" → "Pockets"
+                        if (!equipmentGroups[targetSlot]) equipmentGroups[targetSlot] = []
+                        equipmentGroups[targetSlot].push(item)
+                    } else {
+                        if (!groupedSlots[rule.name]) groupedSlots[rule.name] = []
+                        groupedSlots[rule.name].push(item)
+                    }
+                    matched = true
+                    break
+                }
+            }
+            if (matched) continue
+
+            // Equipment-level slot
+            if (!equipmentGroups[slot]) equipmentGroups[slot] = []
+            equipmentGroups[slot].push(item)
+        }
+
+        // Build ordered slot groups
+        const slots: InvSlotGroup[] = []
+        const usedSlots = new Set<string>()
+
+        // Add in preferred order first
+        for (const slotName of EQUIPMENT_SLOT_ORDER) {
+            if (equipmentGroups[slotName]) {
+                const grpItems = equipmentGroups[slotName]
+                const grpTotal = grpItems.reduce((s, i) => s + i.price * i.qty, 0)
+                const group: InvSlotGroup = { name: slotName, items: grpItems, total: grpTotal }
+
+                // Attach weapon accessories to first weapon slot that has items
+                if (WEAPON_SLOTS.has(slotName) && weaponAttachments.length > 0 && !usedSlots.has('__att__')) {
+                    const weaponName = grpItems[0]?.itemName || slotName
+                    const attTotal = weaponAttachments.reduce((s, i) => s + i.price * i.qty, 0)
+                    group.attachments = { name: weaponName, items: weaponAttachments, total: attTotal }
+                    usedSlots.add('__att__')
+                }
+
+                // Attach grouped sub-slots (helmet_*, armor, plates, pockets) to their parent equipment slot
+                const subGroups: InvSubGroup[] = []
+                const armorParents: Record<string, string[]> = {
+                    'Headwear': ['Helmet parts'],
+                    'ArmorVest': ['Soft armor parts', 'Heavy armor parts', 'Armor plates'],
+                    'TacticalVest': ['Soft armor parts', 'Heavy armor parts', 'Armor plates'],
+                }
+                const parentGroupNames = armorParents[slotName]
+                if (parentGroupNames) {
+                    for (const gn of parentGroupNames) {
+                        if (groupedSlots[gn] && groupedSlots[gn].length > 0) {
+                            const sgTotal = groupedSlots[gn].reduce((s, i) => s + i.price * i.qty, 0)
+                            subGroups.push({ name: gn, items: groupedSlots[gn], total: sgTotal })
+                            delete groupedSlots[gn]
+                        }
+                    }
+                }
+                if (subGroups.length > 0) group.subGroups = subGroups
+
+                slots.push(group)
+                usedSlots.add(slotName)
+            }
+        }
+
+        // Add any remaining equipment slots not in the predefined order
+        for (const slotName of Object.keys(equipmentGroups)) {
+            if (usedSlots.has(slotName)) continue
+            const grpItems = equipmentGroups[slotName]
+            const grpTotal = grpItems.reduce((s, i) => s + i.price * i.qty, 0)
+            const group: InvSlotGroup = { name: slotName, items: grpItems, total: grpTotal }
+            slots.push(group)
+        }
+
+        // Add any remaining grouped slots that didn't attach to a parent
+        for (const [gn, gItems] of Object.entries(groupedSlots)) {
+            if (gItems.length === 0) continue
+            const gTotal = gItems.reduce((s, i) => s + i.price * i.qty, 0)
+            slots.push({ name: gn, items: gItems, total: gTotal })
+        }
+
+        // For 'main' slot: group duplicates by templateId
+        for (const group of slots) {
+            if (group.name === 'main') {
+                const merged: Record<string, TrackingPlayerInventoryItem> = {}
+                for (const item of group.items) {
+                    const key = item.templateId || item.itemName
+                    if (merged[key]) {
+                        merged[key] = { ...merged[key], qty: merged[key].qty + item.qty }
+                    } else {
+                        merged[key] = { ...item }
+                    }
+                }
+                group.items = Object.values(merged)
+            }
+        }
+
+        return { slots, total }
+    }, [selectedBotProfileId, raidData.player_inventory])
+
+    // Reset collapsed slots when bot changes
+    useEffect(() => {
+        if (!selectedBotProfileId) return
+        const defaults: Record<string, boolean> = {}
+        for (const group of selectedBotInventory.slots) {
+            // Collapse: SecondPrimaryWeapon, main
+            defaults[group.name] = group.name === 'SecondPrimaryWeapon' || group.name === 'main'
+            // Weapon attachments always collapsed by default
+            if (group.attachments) {
+                defaults[`${group.name}__att`] = true
+            }
+            // Sub-groups collapsed by default
+            if (group.subGroups) {
+                for (const sg of group.subGroups) {
+                    defaults[`${group.name}__${sg.name}`] = true
+                }
+            }
+        }
+        setCollapsedSlots(defaults)
+    }, [selectedBotProfileId])
+
     function clearMap(m, timeRange) {
         if (!m || !mapIsReady) return;
     
@@ -1325,6 +1768,9 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                                                                             <span className="capitalize">
                                                                                 {intl(getDisplayName(player), intl_dir)} ({getPlayerDifficultyAndBrain(player)})
                                                                             </span>
+                                                                            {botSpawnValues[player.profileId] > 0 && (
+                                                                                <span style={{ fontSize: '9px', opacity: 0.5, marginLeft: '4px' }}>{'\u20BD'}{formatCompactNumber(botSpawnValues[player.profileId])}</span>
+                                                                            )}
                                                                         </div>
                                                                     </div>
                                                                     {followPlayer === player.profileId ? <span className="text-xs">[FOLLOWING]</span> : ''}
@@ -1386,6 +1832,9 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                                                                             <span className="capitalize">
                                                                                 {intl(getDisplayName(player), intl_dir)} ({getPlayerDifficultyAndBrain(player)})
                                                                             </span>
+                                                                            {botSpawnValues[player.profileId] > 0 && (
+                                                                                <span style={{ fontSize: '9px', opacity: 0.5, marginLeft: '4px' }}>{'\u20BD'}{formatCompactNumber(botSpawnValues[player.profileId])}</span>
+                                                                            )}
                                                                         </div>
                                                                     </div>
                                                                     {followPlayer === player.profileId ? <span className="text-xs">[FOLLOWING]</span> : ''}
@@ -1430,6 +1879,9 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                                                                 <span className="capitalize">
                                                                     {intl(getDisplayName(player), intl_dir)} ({getPlayerDifficultyAndBrain(player)})
                                                                 </span>
+                                                                {botSpawnValues[player.profileId] > 0 && (
+                                                                    <span style={{ fontSize: '9px', opacity: 0.5, marginLeft: '4px' }}>{'\u20BD'}{formatCompactNumber(botSpawnValues[player.profileId])}</span>
+                                                                )}
                                                             </div>
                                                         </div>
                                                         {followPlayer === player.profileId ? <span className="text-xs">[FOLLOWING]</span> : ''}
@@ -1442,21 +1894,22 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                             })
                         })()}
                         {showBehavior && <div className="mt-4" style={{ borderTop: '1px solid rgba(154, 136, 102, 0.3)', paddingTop: '8px' }}>
-                            <strong style={{ fontSize: '12px' }}>Bot Behavior</strong>
+                            <strong style={{ fontSize: '13px' }}>Bot Behavior</strong>
                             <div style={{ marginTop: '4px' }}>
                                 {Object.values(BEHAVIOR_CATEGORIES).map(cat => (
-                                    <div key={cat.key} className="flex items-center" style={{ padding: '1px 0', fontSize: '11px' }}>
-                                        <span style={{ width: 8, height: 8, borderRadius: '50%', background: cat.color, marginRight: 6, flexShrink: 0, display: 'inline-block', boxShadow: `0 0 4px ${cat.color}` }}></span>
+                                    <div key={cat.key} className="flex items-center" style={{ padding: '2px 0', fontSize: '12px' }}>
+                                        <span style={{ width: 10, height: 10, borderRadius: '50%', background: cat.color, marginRight: 6, flexShrink: 0, display: 'inline-block', boxShadow: `0 0 4px ${cat.color}` }}></span>
                                         <span>{cat.label}</span>
                                     </div>
                                 ))}
                             </div>
                             {!raidData?.detectedMods?.match(/SAIN/gi) && (
-                                <div style={{ marginTop: '6px', fontSize: '9px', color: '#F59E0B', opacity: 0.7 }}>
+                                <div style={{ marginTop: '6px', fontSize: '11px', color: '#F59E0B', opacity: 0.7 }}>
                                     SAIN recommended for detailed behavior data
                                 </div>
                             )}
                         </div>}
+
                     </div>
                 </aside>
                 <div className="map-wrapper border border-eft map">
@@ -1509,6 +1962,250 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                     </div>
                     <div id="leaflet-map" ref={onMapContainerRefChange} className={'leaflet-map-container'} />
                 </div>
+                <aside className="sidebar-right border border-eft ml-3 p-3 overflow-x-auto">
+                    <div className="playerfeed text-eft">
+                        {/* ── Loose Loot Section ── */}
+                        <div>
+                            <div
+                                className="flex items-center cursor-pointer"
+                                style={{ fontSize: '14px' }}
+                                onClick={() => setLooseLootCollapsed(!looseLootCollapsed)}
+                            >
+                                <span style={{ marginRight: '4px', fontSize: '9px' }}>{looseLootCollapsed ? '\u25B6' : '\u25BC'}</span>
+                                <strong>Loose Loot</strong>
+                            </div>
+                            {!looseLootCollapsed && (
+                                <div style={{ marginTop: '6px', fontSize: '13px' }}>
+                                    <label className="flex items-center gap-2 cursor-pointer" style={{ marginBottom: '6px' }}>
+                                        <input
+                                            type="checkbox"
+                                            checked={showLooseLoot}
+                                            onChange={() => setShowLooseLoot(!showLooseLoot)}
+                                            style={{ accentColor: '#9a8866' }}
+                                        />
+                                        <span>Show on map</span>
+                                    </label>
+
+                                    <div style={{ marginBottom: '6px' }}>
+                                        <div className="flex justify-between" style={{ fontSize: '12px', marginBottom: '2px' }}>
+                                            <span>Min price</span>
+                                            <span>{'\u20BD'}{looseLootMinPrice.toLocaleString()}</span>
+                                        </div>
+                                        <input
+                                            type="range"
+                                            min={0}
+                                            max={500000}
+                                            step={5000}
+                                            value={looseLootMinPrice}
+                                            onChange={(e) => setLooseLootMinPrice(Number(e.target.value))}
+                                            style={{ width: '100%', accentColor: '#9a8866' }}
+                                        />
+                                    </div>
+
+                                    <div style={{ marginBottom: '6px' }}>
+                                        <div style={{ fontSize: '12px', marginBottom: '2px' }}>Filter</div>
+                                        <select
+                                            value={looseLootFilter}
+                                            onChange={(e) => setLooseLootFilter(e.target.value as 'all' | 'ground' | 'container')}
+                                            style={{ width: '100%', background: '#1a1a1a', color: '#9a8866', border: '1px solid #9a8866', padding: '3px 4px', fontSize: '12px' }}
+                                        >
+                                            <option value="all">All</option>
+                                            <option value="ground">Ground only</option>
+                                            <option value="container">Container only</option>
+                                        </select>
+                                    </div>
+
+                                    <div style={{ fontSize: '11px', opacity: 0.7, marginBottom: '4px' }}>
+                                        {looseLootStats.shown} items shown / {looseLootStats.total} total ({looseLootStats.ground} ground, {looseLootStats.container} container)
+                                    </div>
+
+                                    {showLooseLoot && looseLootData.length > 0 && (
+                                        <div style={{ maxHeight: '300px', overflowY: 'auto', borderTop: '1px solid rgba(154,136,102,0.2)', paddingTop: '4px' }}>
+                                            {[...looseLootData]
+                                                .filter(item => {
+                                                    if (item.itemId && pickedUpItemIds.has(item.itemId)) return false
+                                                    const tp = item.price * item.qty
+                                                    if (tp < looseLootMinPrice) return false
+                                                    const isC = item.inContainer === true || item.inContainer === 1
+                                                    if (looseLootFilter === 'ground' && isC) return false
+                                                    if (looseLootFilter === 'container' && !isC) return false
+                                                    return true
+                                                })
+                                                .sort((a, b) => (b.price * b.qty) - (a.price * a.qty))
+                                                .slice(0, 100)
+                                                .map((item, idx) => {
+                                                    const isC = item.inContainer === true || (item.inContainer as any) === 1
+                                                    const tp = item.price * item.qty
+                                                    return (
+                                                        <div
+                                                            key={idx}
+                                                            className="flex items-center"
+                                                            style={{ padding: '1px 0', fontSize: '12px', gap: '4px', cursor: 'pointer' }}
+                                                            onMouseEnter={() => highlightLooseLootItem(item)}
+                                                            onMouseLeave={() => highlightLooseLootItem(null)}
+                                                        >
+                                                            <span style={{ color: getLootPriceColor(tp), fontSize: '9px', flexShrink: 0 }}>{isC ? '\u25A0' : '\u25C6'}</span>
+                                                            <span style={{ color: getLootPriceColor(tp), overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+                                                                {item.itemName}
+                                                            </span>
+                                                            <span style={{ opacity: 0.7, flexShrink: 0 }}>
+                                                                {item.qty > 1 ? `x${item.qty} ` : ''}{'\u20BD'}{tp.toLocaleString()}
+                                                            </span>
+                                                        </div>
+                                                    )
+                                                })
+                                            }
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+
+                        {/* ── Bot Inventory Section ── */}
+                        {botsWithInventory.length > 0 && (
+                            <div className="mt-4" style={{ borderTop: '1px solid rgba(154, 136, 102, 0.3)', paddingTop: '8px' }}>
+                                <div
+                                    className="flex items-center cursor-pointer"
+                                    style={{ fontSize: '14px' }}
+                                    onClick={() => setBotInvCollapsed(!botInvCollapsed)}
+                                >
+                                    <span style={{ marginRight: '4px', fontSize: '9px' }}>{botInvCollapsed ? '\u25B6' : '\u25BC'}</span>
+                                    <strong>Bot Inventory</strong>
+                                </div>
+                                {!botInvCollapsed && (
+                                    <div style={{ marginTop: '6px', fontSize: '13px' }}>
+                                        {/* Bot selector with colored dots */}
+                                        <div style={{ maxHeight: '180px', overflowY: 'auto', border: '1px solid rgba(154,136,102,0.4)', marginBottom: '6px', background: '#111' }}>
+                                            {botsWithInventory.map(bot => {
+                                                const bIdx = raidData.players?.indexOf(bot) ?? 0
+                                                const bColor = getPlayerColor(bot, bIdx)
+                                                const isSelected = bot.profileId === selectedBotProfileId
+                                                return (
+                                                    <div
+                                                        key={bot.profileId}
+                                                        onClick={() => setSelectedBotProfileId(isSelected ? '' : bot.profileId)}
+                                                        className="flex items-center cursor-pointer"
+                                                        style={{
+                                                            padding: '3px 6px', fontSize: '12px',
+                                                            background: isSelected ? 'rgba(154,136,102,0.25)' : 'transparent',
+                                                            borderLeft: isSelected ? '2px solid #9a8866' : '2px solid transparent',
+                                                        }}
+                                                    >
+                                                        <span style={{ display: 'inline-block', width: '8px', height: '8px', borderRadius: '50%', background: bColor, marginRight: '5px', flexShrink: 0 }} />
+                                                        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                                            {getDisplayName(bot)}
+                                                        </span>
+                                                        {botSpawnValues[bot.profileId] > 0 && (
+                                                            <span style={{ marginLeft: 'auto', paddingLeft: '4px', opacity: 0.6, flexShrink: 0 }}>
+                                                                {'\u20BD'}{formatCompactNumber(botSpawnValues[bot.profileId])}
+                                                            </span>
+                                                        )}
+                                                    </div>
+                                                )
+                                            })}
+                                        </div>
+
+                                        {selectedBotProfileId && selectedBotInventory.slots.length > 0 && (
+                                            <div style={{ maxHeight: 'calc(100vh - 400px)', overflowY: 'auto' }}>
+                                                {selectedBotInventory.slots.map((group) => {
+                                                    const isSlotCollapsed = collapsedSlots[group.name] ?? false
+                                                    const attKey = `${group.name}__att`
+                                                    const isAttCollapsed = collapsedSlots[attKey] ?? true
+                                                    return (
+                                                        <div key={group.name} style={{ marginBottom: '4px' }}>
+                                                            {/* Slot header */}
+                                                            <div
+                                                                className="flex items-center justify-between cursor-pointer"
+                                                                onClick={() => toggleSlotCollapse(group.name)}
+                                                                style={{ fontSize: '13px', fontWeight: 'bold', opacity: 0.9, borderBottom: '1px solid rgba(154,136,102,0.2)', marginBottom: '2px', paddingBottom: '2px', userSelect: 'none' }}
+                                                            >
+                                                                <span>
+                                                                    <span style={{ fontSize: '9px', marginRight: '3px' }}>{isSlotCollapsed ? '\u25B6' : '\u25BC'}</span>
+                                                                    {group.name} <span style={{ fontWeight: 'normal', opacity: 0.6 }}>({group.items.length})</span>
+                                                                </span>
+                                                                {!NON_LOOTABLE_SLOTS.test(group.name) && <span style={{ fontWeight: 'normal', opacity: 0.6, fontSize: '12px' }}>{'\u20BD'}{group.total.toLocaleString()}</span>}
+                                                            </div>
+                                                            {/* Slot items */}
+                                                            {!isSlotCollapsed && group.items.map((item, idx) => (
+                                                                <div key={idx} className="flex justify-between" style={{ padding: '1px 0 1px 10px', fontSize: '12px' }}>
+                                                                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '60%' }}>
+                                                                        {item.itemName}
+                                                                    </span>
+                                                                    <span style={{ opacity: 0.7 }}>
+                                                                        {item.qty > 1 ? `x${item.qty} ` : ''}{!NON_LOOTABLE_SLOTS.test(group.name) && <>{'\u20BD'}{(item.price * item.qty).toLocaleString()}</>}
+                                                                    </span>
+                                                                </div>
+                                                            ))}
+                                                            {/* Weapon attachments sub-group */}
+                                                            {!isSlotCollapsed && group.attachments && group.attachments.items.length > 0 && (
+                                                                <div style={{ marginTop: '2px', marginLeft: '10px' }}>
+                                                                    <div
+                                                                        className="flex items-center justify-between cursor-pointer"
+                                                                        onClick={() => toggleSlotCollapse(attKey)}
+                                                                        style={{ fontSize: '12px', fontWeight: 'bold', opacity: 0.7, marginBottom: '2px', userSelect: 'none' }}
+                                                                    >
+                                                                        <span>
+                                                                            <span style={{ fontSize: '8px', marginRight: '3px' }}>{isAttCollapsed ? '\u25B6' : '\u25BC'}</span>
+                                                                            {group.attachments.name} parts <span style={{ fontWeight: 'normal' }}>({group.attachments.items.length})</span>
+                                                                        </span>
+                                                                        <span style={{ fontWeight: 'normal', fontSize: '11px' }}>{'\u20BD'}{group.attachments.total.toLocaleString()}</span>
+                                                                    </div>
+                                                                    {!isAttCollapsed && group.attachments.items.map((item, idx) => (
+                                                                        <div key={idx} className="flex justify-between" style={{ padding: '1px 0 1px 10px', fontSize: '11px', opacity: 0.8 }}>
+                                                                            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '55%' }}>
+                                                                                {item.itemName}
+                                                                            </span>
+                                                                            <span style={{ opacity: 0.6 }}>
+                                                                                {item.qty > 1 ? `x${item.qty} ` : ''}{'\u20BD'}{(item.price * item.qty).toLocaleString()}
+                                                                            </span>
+                                                                        </div>
+                                                                    ))}
+                                                                </div>
+                                                            )}
+                                                            {/* Other sub-groups (helmet, armor, plates, pockets) */}
+                                                            {!isSlotCollapsed && group.subGroups && group.subGroups.map(sg => {
+                                                                const sgKey = `${group.name}__${sg.name}`
+                                                                const isSgCollapsed = collapsedSlots[sgKey] ?? true
+                                                                return (
+                                                                    <div key={sg.name} style={{ marginTop: '2px', marginLeft: '10px' }}>
+                                                                        <div
+                                                                            className="flex items-center justify-between cursor-pointer"
+                                                                            onClick={() => toggleSlotCollapse(sgKey)}
+                                                                            style={{ fontSize: '12px', fontWeight: 'bold', opacity: 0.7, marginBottom: '2px', userSelect: 'none' }}
+                                                                        >
+                                                                            <span>
+                                                                                <span style={{ fontSize: '8px', marginRight: '3px' }}>{isSgCollapsed ? '\u25B6' : '\u25BC'}</span>
+                                                                                {sg.name} <span style={{ fontWeight: 'normal' }}>({sg.items.length})</span>
+                                                                            </span>
+                                                                            <span style={{ fontWeight: 'normal', fontSize: '11px' }}>{'\u20BD'}{sg.total.toLocaleString()}</span>
+                                                                        </div>
+                                                                        {!isSgCollapsed && sg.items.map((item, idx) => (
+                                                                            <div key={idx} className="flex justify-between" style={{ padding: '1px 0 1px 10px', fontSize: '11px', opacity: 0.8 }}>
+                                                                                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '55%' }}>
+                                                                                    {item.itemName}
+                                                                                </span>
+                                                                                <span style={{ opacity: 0.6 }}>
+                                                                                    {item.qty > 1 ? `x${item.qty} ` : ''}{'\u20BD'}{(item.price * item.qty).toLocaleString()}
+                                                                                </span>
+                                                                            </div>
+                                                                        ))}
+                                                                    </div>
+                                                                )
+                                                            })}
+                                                        </div>
+                                                    )
+                                                })}
+                                                <div style={{ borderTop: '1px solid rgba(154,136,102,0.3)', paddingTop: '4px', marginTop: '4px', fontWeight: 'bold', fontSize: '13px' }}>
+                                                    Total: {'\u20BD'}{selectedBotInventory.total.toLocaleString()}
+                                                </div>
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                </aside>
                 <div className="dev__time_sliders p-3 border border-eft mt-4 timeline">
                     <PlayerSlider
                         events={hideEvents ? [] : events}

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -16,6 +16,7 @@ import { TrackingPositionalData } from '../types/api_types.js';
 import { PlayerSlider } from './MapPlayerSlider.js';
 
 import BotMapping from '../assets/botMapping.json'
+import { getMarkerLabel, getPlayerColor, getLegendIcon, PMC_COLORS, buildPmcIndexMap } from '../helpers/players'
 
 import 'leaflet/dist/leaflet.css';
 
@@ -60,24 +61,6 @@ function classifyPlayer(player: any): string {
     }
 }
 
-function getLegendIcon(player: any, color: string, pmcIdx?: number): JSX.Element {
-    const label = getMarkerLabel(player)
-    if (label === 'BTR_ICON') {
-        // BTR vehicle icon
-        return <span style={{ width: '24px', height: '18px', marginRight: '4px', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}><svg viewBox="0 0 24 18" width="24" height="18" fill="none"><rect x="2" y="3" width="20" height="8" rx="1" fill={color}/><rect x="5" y="1" width="10" height="4" rx="1" fill={color}/><line x1="15" y1="3" x2="20" y2="5" stroke={color} strokeWidth="1.2"/><circle cx="5.5" cy="13.5" r="2.5" fill={color}/><circle cx="12" cy="13.5" r="2.5" fill={color}/><circle cx="18.5" cy="13.5" r="2.5" fill={color}/><circle cx="5.5" cy="13.5" r="1" fill="#1a1a1a"/><circle cx="12" cy="13.5" r="1" fill="#1a1a1a"/><circle cx="18.5" cy="13.5" r="1" fill="#1a1a1a"/></svg></span>
-    }
-    if (label) {
-        // Square marker with letter — matches map
-        return <span style={{ width: '18px', height: '18px', borderRadius: '2px', marginRight: '6px', background: color, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: '9px', fontWeight: 'bold', color: '#fff', textShadow: '0 0 2px rgba(0,0,0,0.9)', border: '1px solid rgba(255,255,255,0.6)', flexShrink: 0, lineHeight: 1 }}>{label}</span>
-    }
-    if (pmcIdx !== undefined) {
-        // Round marker with number — matches map
-        return <span style={{ width: '18px', height: '18px', borderRadius: '50%', marginRight: '6px', background: color, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: '9px', fontWeight: 'bold', color: '#fff', textShadow: '0 0 2px rgba(0,0,0,0.9)', border: '1px solid rgba(255,255,255,0.6)', flexShrink: 0, lineHeight: 1 }}>{pmcIdx}</span>
-    }
-    // Plain circle for scavs
-    return <span style={{ width: '10px', height: '10px', minWidth: '10px', minHeight: '10px', borderRadius: '50%', marginRight: '6px', background: color, border: '1px solid rgba(255,255,255,0.4)', flexShrink: 0, display: 'inline-block' }}></span>
-}
-
 const LEGEND_GROUPS = [
     { key: 'PMC', label: 'PMC' },
     { key: 'PLAYER_SCAV', label: 'Player Scav' },
@@ -88,50 +71,6 @@ const LEGEND_GROUPS = [
     { key: 'FACTION', label: 'Faction' },
     { key: 'SCAV', label: 'Scav' },
 ] as const
-
-function getMarkerLabel(player: any): string | null {
-    const type = (player?.type || '').toUpperCase()
-
-    // Bosses
-    if (type.includes('KILLA')) return 'Ki'
-    if (type.includes('RASHALA')) return 'Ra'
-    if (type.includes('SHTURMAN')) return 'Sh'
-    if (type.includes('TAGILLA')) return 'Ta'
-    if (type.includes('SANITAR')) return 'Sa'
-    if (type.includes('GLUHAR')) return 'Gl'
-    if (type.includes('ZRYACHIY')) return 'Zr'
-    if (type.includes('KABAN')) return 'Kb'
-    if (type.includes('KOLONTAY')) return 'Ko'
-    if (type.includes('PARTIZAN')) return 'P'
-
-    // Goons
-    if (type.includes('KNIGHT')) return 'Kn'
-    if (type.includes('BIGPIPE')) return 'BP'
-    if (type.includes('BIRDEYE')) return 'BE'
-
-    // Factions
-    if (type.includes('MERCENARY')) return 'M'
-    if (type.includes('RUAF')) return 'R'
-    if (type.includes('UNTAR')) return 'U'
-    if (type.includes('BLACK DIV')) return 'BD'
-
-    // Labyrinth
-    if (type.includes('SHADOW TAGILLA')) return 'ST'
-    if (type.includes('VENGEFUL KILLA')) return 'VK'
-    if (type.includes('INFECTED')) return 'If'
-    if (type.includes('SPIRIT')) return 'Sp'
-
-    // Special types
-    if (type.includes('RAIDER')) return 'Rd'
-    if (type.includes('ROGUE')) return 'Rg'
-    if (type.includes('CULTIST PRIEST')) return 'CP'
-    if (type.includes('CULTIST')) return 'Cu'
-    if (type.includes('BLOODHOUND')) return 'Bh'
-    if (type.includes('BTR')) return 'BTR_ICON'
-    if (type.includes('SNIPER')) return 'Sn'
-
-    return null
-}
 
 function getTooltipIconHtml(player: any, color: string, pmcIdx?: number): string {
     const label = getMarkerLabel(player)
@@ -275,55 +214,6 @@ function calculateProportionalRadius(mapBounds, zoomLevel) {
     return baseRadius * scalingFactor / zoomAdjustment;
 }
   
-const colors = [
-    "#3357FF", // Blue
-    "#FFD433", // Yellow
-    "#33FFF3", // Cyan
-    "#9370DB", // MediumPurple
-    "#BC8F8F", // RosyBrown
-    "#FF5733", // Red-Orange
-    "#7FFFD4", // Aquamarine
-    "#FFFF99", // Canary
-    "#ae85f9", // Light Purple
-    "#FF9633", // Orange
-    "#3366FF", // Royal Blue
-    "#B87333", // Copper
-    "#FFA533", // Light Orange
-    "#33FFAF", // Mint Green
-    "#5733FF", // Indigo
-    "#FF33D4", // Light Magenta
-    "#33FFCC", // Teal
-    "#FF5733", // Coral
-    "#5733FF", // Dark Violet
-    "#FFD433", // Gold
-    "#B833FF", // Violet
-    "#33FF57", // Lime
-    "#33FF57", // Forest Green
-    "#660000", // Blood red
-    "#3399FF", // Sky Blue
-    "#FF33B8", // Rose
-    "#8CFF33", // Lime Green
-    "#33FFD5", // Turquoise
-    "#FF6F33", // Dark Orange
-    "#FF3333", // Crimson
-    "#FF5733", // Tomato
-    "#33D4FF", // Deep Sky Blue
-    "#FF5733", // Salmon
-    "#FF3380", // Deep Pink
-    "#33FF57", // Spring Green
-    "#33FF57", // Medium Sea Green
-    "#FF33E9", // Orchid
-    "#FFD433", // Khaki
-    "#ae85f9", // Light Purple
-    "#FF33D4", // Light Pink
-    "#8D33FF", // Plum
-    "#33FFF3", // Light Cyan
-    "#FF9633", // Dark Salmon
-    "#33FF8D", // Pale Green
-    "#FF33A1", // Deep Pink
-    "#33FF8D", // Sea Green
-    "#33FFF3", // Aqua
-];
 
 export default function MapComponent({ raidData, raidId, positions, intl_dir }) {
     const navigate = useNavigate()
@@ -367,21 +257,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
     const [events, setEvents] = useState([])
 
     // Pre-compute PMC index within each team group (for numbered markers in legend + map)
-    const pmcIndexMap = useMemo(() => {
-        const map: Record<string, number> = {}
-        const groupCounters: Record<number, number> = {}
-        for (const p of raidData.players) {
-            const isPMC = p.team === 'Usec' || p.team === 'Bear'
-            const isHuman = p.type === 'HUMAN'
-            if (isPMC || isHuman) {
-                const group = p.group ?? 0
-                if (groupCounters[group] === undefined) groupCounters[group] = 0
-                groupCounters[group]++
-                map[p.profileId] = groupCounters[group]
-            }
-        }
-        return map
-    }, [raidData.players])
+    const pmcIndexMap = useMemo(() => buildPmcIndexMap(raidData.players), [raidData.players])
 
     const focusItem = useRef(searchParams.get('q') ? searchParams.get('q').split(',') : [])
     const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -1308,62 +1184,6 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
         }
 
         return ''
-    }
-
-    function getPlayerColor(player: TrackingRaidDataPlayers, index: number): string {
-        if (player === undefined) {
-            console.debug(player, index)
-            return
-        }
-
-        let botMapping = BotMapping[player.type]
-        if (player.name === 'Knight') {
-            botMapping = {
-                type: 'GOON',
-            }
-        }
-        if (!botMapping) {
-            botMapping = {
-                type: 'UNKNOWN',
-            }
-        }
-
-        switch (botMapping.type) {
-            case 'SCAV':
-                return '#33FF57' // Green - Scav
-            case 'BOSS':
-                return '#FF0000' // Red - Boss
-            case 'ROGUE':
-            case 'FOLLOWER':
-                return '#ff7b00' // Orange - Follower
-            case 'BLOODHOUND':
-                return '#6d0000' // Dark Red - Raider
-            case 'RAIDER':
-                return '#FF00FF' // Magenta - Raider
-            case 'PLAYER_SCAV':
-                return '#33FF8D' // Light Green - Scav Player
-            case 'SNIPER':
-                return '#00911a' // Dark Green - Sniper
-            case 'GOON':
-                return '#ff005d' // Between Magenta & Red  - Goon
-            case 'CULT':
-                return '#6f00ff' // Dark Purple - Cultist
-            case 'OTHER':
-                return '#00eeff' // Other - Cyan
-            case 'MERCENARY':
-                return '#FFD700' // Gold - Mercenary
-            case 'RUAF':
-                return '#4A90D9' // Steel Blue - RUAF
-            case 'UNTAR':
-                return '#00BFFF' // Light Blue - UNTAR
-            case 'BLACKDIV':
-                return '#555555' // Dark Grey - Black Division
-            case 'INFECTED':
-                return '#7FFF00' // Chartreuse - Infected (Labyrinth)
-            default:
-                if (player.type === 'PLAYER' && player.team === 'Savage') return '#33FF57' // Green - Scav
-                else return colors[(player.group ?? index) % colors.length] // PMC - color by team group
-        }
     }
 
     return (

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -47,7 +47,8 @@ function classifyPlayer(player: any): string {
         case 'CULT':
         case 'BLOODHOUND':
         case 'SNIPER':
-        case 'INFECTED': return 'SPECIAL'
+        case 'INFECTED':
+        case 'OTHER': return 'SPECIAL'
         case 'MERCENARY':
         case 'RUAF':
         case 'UNTAR':
@@ -61,6 +62,10 @@ function classifyPlayer(player: any): string {
 
 function getLegendIcon(player: any, color: string, pmcIdx?: number): JSX.Element {
     const label = getMarkerLabel(player)
+    if (label === 'BTR_ICON') {
+        // BTR vehicle icon
+        return <span style={{ width: '24px', height: '18px', marginRight: '4px', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}><svg viewBox="0 0 24 18" width="24" height="18" fill="none"><rect x="2" y="3" width="20" height="8" rx="1" fill={color}/><rect x="5" y="1" width="10" height="4" rx="1" fill={color}/><line x1="15" y1="3" x2="20" y2="5" stroke={color} strokeWidth="1.2"/><circle cx="5.5" cy="13.5" r="2.5" fill={color}/><circle cx="12" cy="13.5" r="2.5" fill={color}/><circle cx="18.5" cy="13.5" r="2.5" fill={color}/><circle cx="5.5" cy="13.5" r="1" fill="#1a1a1a"/><circle cx="12" cy="13.5" r="1" fill="#1a1a1a"/><circle cx="18.5" cy="13.5" r="1" fill="#1a1a1a"/></svg></span>
+    }
     if (label) {
         // Square marker with letter — matches map
         return <span style={{ width: '18px', height: '18px', borderRadius: '2px', marginRight: '6px', background: color, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: '9px', fontWeight: 'bold', color: '#fff', textShadow: '0 0 2px rgba(0,0,0,0.9)', border: '1px solid rgba(255,255,255,0.6)', flexShrink: 0, lineHeight: 1 }}>{label}</span>
@@ -122,7 +127,7 @@ function getMarkerLabel(player: any): string | null {
     if (type.includes('CULTIST PRIEST')) return 'CP'
     if (type.includes('CULTIST')) return 'Cu'
     if (type.includes('BLOODHOUND')) return 'Bh'
-    if (type.includes('BTR')) return 'BT'
+    if (type.includes('BTR')) return 'BTR_ICON'
     if (type.includes('SNIPER')) return 'Sn'
 
     return null
@@ -132,6 +137,16 @@ function createPlayerMarker(latlng: any, color: string, player: any, proportiona
     const displayName = tooltipText || getDisplayName(player)
     const tooltipOpts: L.TooltipOptions = { direction: 'top', offset: [0, -10], className: 'player-tooltip' }
     const label = getMarkerLabel(player)
+    if (label === 'BTR_ICON') {
+        const btrSvg = `<svg viewBox="0 0 24 18" width="24" height="18" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="2" y="3" width="20" height="8" rx="1" fill="${color}" opacity="${opacity}"/><rect x="5" y="1" width="10" height="4" rx="1" fill="${color}" opacity="${opacity}"/><line x1="15" y1="3" x2="20" y2="5" stroke="${color}" stroke-width="1.2" opacity="${opacity}"/><circle cx="5.5" cy="13.5" r="2.5" fill="${color}" opacity="${opacity}"/><circle cx="12" cy="13.5" r="2.5" fill="${color}" opacity="${opacity}"/><circle cx="18.5" cy="13.5" r="2.5" fill="${color}" opacity="${opacity}"/><circle cx="5.5" cy="13.5" r="1" fill="#1a1a1a"/><circle cx="12" cy="13.5" r="1" fill="#1a1a1a"/><circle cx="18.5" cy="13.5" r="1" fill="#1a1a1a"/></svg>`
+        const icon = L.divIcon({
+            className: 'special-bot-marker',
+            html: `<div style="display:flex;align-items:center;justify-content:center;filter:drop-shadow(0 0 2px rgba(0,0,0,0.9));">${btrSvg}</div>`,
+            iconSize: [24, 20],
+            iconAnchor: [12, 10],
+        })
+        return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, tooltipOpts)
+    }
     if (label) {
         const icon = L.divIcon({
             className: 'special-bot-marker',
@@ -1069,6 +1084,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
             if (botMapping.type === 'PLAYER_SCAV') brainOutput = `${player.mod_SAIN_brain.trim()} - Player Scav`
             if (botMapping.type === 'BLOODHOUND') brainOutput = `Bloodhound`
             if (botMapping.type === 'INFECTED') brainOutput = `Infected`
+            if (botMapping.type === 'OTHER') brainOutput = `BTR`
 
             return brainOutput
         }

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -17,6 +17,7 @@ import { PlayerSlider } from './MapPlayerSlider.js';
 
 import BotMapping from '../assets/botMapping.json'
 import { getMarkerLabel, getPlayerColor, getLegendIcon, PMC_COLORS, buildPmcIndexMap } from '../helpers/players'
+import { getBehaviorCategory, BEHAVIOR_CATEGORIES, formatDecisionLabel } from '../helpers/botBehavior'
 
 import 'leaflet/dist/leaflet.css';
 
@@ -83,40 +84,51 @@ function getTooltipIconHtml(player: any, color: string, pmcIdx?: number): string
     return `<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${color};vertical-align:middle;margin-right:3px;"></span>`
 }
 
-function createPlayerMarker(latlng: any, color: string, player: any, proportionalScale: number, opacity: number = 1, pmcIndex?: number, tooltipText?: string): L.Layer {
+function createPlayerMarker(latlng: any, color: string, player: any, proportionalScale: number, opacity: number = 1, pmcIndex?: number, tooltipText?: string, behaviorColor?: string | null): L.Layer {
     const displayName = tooltipText || getDisplayName(player)
     const tooltipOpts: L.TooltipOptions = { direction: 'top', offset: [0, -10], className: 'player-tooltip' }
+    const ringStyle = behaviorColor ? `box-shadow: 0 0 0 3px ${behaviorColor}, 0 0 6px 1px ${behaviorColor}55;` : ''
     const label = getMarkerLabel(player)
     if (label === 'BTR_ICON') {
         const btrSvg = `<svg viewBox="0 0 24 18" width="24" height="18" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="2" y="3" width="20" height="8" rx="1" fill="${color}" opacity="${opacity}"/><rect x="5" y="1" width="10" height="4" rx="1" fill="${color}" opacity="${opacity}"/><line x1="15" y1="3" x2="20" y2="5" stroke="${color}" stroke-width="1.2" opacity="${opacity}"/><circle cx="5.5" cy="13.5" r="2.5" fill="${color}" opacity="${opacity}"/><circle cx="12" cy="13.5" r="2.5" fill="${color}" opacity="${opacity}"/><circle cx="18.5" cy="13.5" r="2.5" fill="${color}" opacity="${opacity}"/><circle cx="5.5" cy="13.5" r="1" fill="#1a1a1a"/><circle cx="12" cy="13.5" r="1" fill="#1a1a1a"/><circle cx="18.5" cy="13.5" r="1" fill="#1a1a1a"/></svg>`
         const icon = L.divIcon({
             className: 'special-bot-marker',
-            html: `<div style="display:flex;align-items:center;justify-content:center;filter:drop-shadow(0 0 2px rgba(0,0,0,0.9));">${btrSvg}</div>`,
+            html: `<div style="display:flex;align-items:center;justify-content:center;filter:drop-shadow(0 0 2px rgba(0,0,0,0.9));${ringStyle}">${btrSvg}</div>`,
             iconSize: [24, 20],
             iconAnchor: [12, 10],
         })
-        return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, tooltipOpts)
+        return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, { ...tooltipOpts, className: 'player-tooltip player-tooltip-html' })
     }
     if (label) {
         const icon = L.divIcon({
             className: 'special-bot-marker',
-            html: `<div class="bot-marker-dot" style="background-color: ${color}; opacity: ${opacity};">${label}</div>`,
+            html: `<div class="bot-marker-dot" style="background-color: ${color}; opacity: ${opacity}; ${ringStyle}">${label}</div>`,
             iconSize: [18, 18],
             iconAnchor: [9, 9],
         })
-        return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, tooltipOpts)
+        return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, { ...tooltipOpts, className: 'player-tooltip player-tooltip-html' })
     }
     // PMCs and player scavs get white border + number label
     if (pmcIndex !== undefined) {
         const icon = L.divIcon({
             className: 'special-bot-marker',
-            html: `<div class="bot-marker-dot bot-marker-round" style="background-color: ${color}; opacity: ${opacity};">${pmcIndex}</div>`,
+            html: `<div class="bot-marker-dot bot-marker-round" style="background-color: ${color}; opacity: ${opacity}; ${ringStyle}">${pmcIndex}</div>`,
             iconSize: [18, 18],
             iconAnchor: [9, 9],
         })
-        return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, tooltipOpts)
+        return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, { ...tooltipOpts, className: 'player-tooltip player-tooltip-html' })
     }
-    // Scavs: plain circle, no border
+    // Scavs: plain circle — use divIcon for behavior ring support
+    if (behaviorColor) {
+        const size = Math.max(10, proportionalScale * 2)
+        const icon = L.divIcon({
+            className: 'special-bot-marker',
+            html: `<div style="width:${size}px;height:${size}px;border-radius:50%;background:${color};opacity:${opacity};${ringStyle}"></div>`,
+            iconSize: [size, size],
+            iconAnchor: [size / 2, size / 2],
+        })
+        return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, { ...tooltipOpts, className: 'player-tooltip player-tooltip-html' })
+    }
     return L.circle(latlng, { radius: proportionalScale, color, fillOpacity: opacity, fillRule: 'nonzero', opacity }).bindTooltip(displayName, tooltipOpts)
 }
 import '../modules/leaflet-heat.js'
@@ -248,6 +260,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
     const [sliderTimes, setSliderTimes] = useState([])
     const [hideSettings, setHideSettings] = useState(true)
     const [hidePlayers, setHidePlayers] = useState(false)
+    const [showBehavior, setShowBehavior] = useState(!!raidData?.detectedMods?.match(/SAIN/gi))
     const [hideEvents, setHideEvents] = useState(false)
     const [hideBallistics, setHideBallistics] = useState(false)
     const [hideNerdStats, setHideNerdStats] = useState(true)
@@ -684,8 +697,26 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                 pl._rr_normalOpacity = preserveHistory ? 0.8 : isPlayerDead ? 0 : 0.8
 
                 if (!isPlayerDead) {
-                    const tip = `${getDisplayName(player)} (${getPlayerDifficultyAndBrain(player)})`
-                    const marker = createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, markerOpacity, pmcIndexMap[playerId], tip)
+                    // Get latest behavior decision from position data (skip BTR)
+                    const isBTR = player?.type?.includes('BTR')
+                    let currentDecision: string | undefined
+                    let behaviorCat = null
+                    let behaviorLine = ''
+                    if (showBehavior && !isBTR) {
+                        const pp = positions[playerId]
+                        if (pp) {
+                            for (let di = pp.length - 1; di >= 0; di--) {
+                                if (pp[di].time <= timeEndLimit) {
+                                    currentDecision = pp[di].decision
+                                    break
+                                }
+                            }
+                        }
+                        behaviorCat = getBehaviorCategory(currentDecision)
+                        behaviorLine = behaviorCat ? `<br/><span style="color:${behaviorCat.color}">${behaviorCat.label}</span>: ${formatDecisionLabel(currentDecision)}` : ''
+                    }
+                    const tip = `${getDisplayName(player)} (${getPlayerDifficultyAndBrain(player)})${behaviorLine}`
+                    const marker = createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, markerOpacity, pmcIndexMap[playerId], tip, behaviorCat?.color)
                     marker._rr_playerId = playerId
                     marker._rr_isDead = false
                     marker._rr_normalOpacity = 1
@@ -724,7 +755,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
             setTimeEndLimit(times[times.length - 1])
             setTimeCurrentIndex(times.length - 1)
         }
-    }, [mapIsReady, mapViewRef, timeEndLimit, timeStartLimit, timeCurrentIndex, MAP, preserveHistory, events, hideEvents, hidePlayers, followPlayer, pmcIndexMap])
+    }, [mapIsReady, mapViewRef, timeEndLimit, timeStartLimit, timeCurrentIndex, MAP, preserveHistory, events, hideEvents, hidePlayers, followPlayer, pmcIndexMap, showBehavior])
 
     // Focus overlay: adjusts layer opacity + kill visualization without full re-render
     useEffect(() => {
@@ -1409,6 +1440,22 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                                 )
                             })
                         })()}
+                        {showBehavior && <div className="mt-4" style={{ borderTop: '1px solid rgba(154, 136, 102, 0.3)', paddingTop: '8px' }}>
+                            <strong style={{ fontSize: '12px' }}>Bot Behavior</strong>
+                            <div style={{ marginTop: '4px' }}>
+                                {Object.values(BEHAVIOR_CATEGORIES).map(cat => (
+                                    <div key={cat.key} className="flex items-center" style={{ padding: '1px 0', fontSize: '11px' }}>
+                                        <span style={{ width: 8, height: 8, borderRadius: '50%', background: cat.color, marginRight: 6, flexShrink: 0, display: 'inline-block', boxShadow: `0 0 4px ${cat.color}` }}></span>
+                                        <span>{cat.label}</span>
+                                    </div>
+                                ))}
+                            </div>
+                            {!raidData?.detectedMods?.match(/SAIN/gi) && (
+                                <div style={{ marginTop: '6px', fontSize: '9px', color: '#F59E0B', opacity: 0.7 }}>
+                                    SAIN recommended for detailed behavior data
+                                </div>
+                            )}
+                        </div>}
                     </div>
                 </aside>
                 <div className="map-wrapper border border-eft map">
@@ -1520,6 +1567,9 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                             </button>
                             <button className={`text-xs p-1 text-sm cursor-pointer ${!hideNerdStats ? 'bg-eft text-black ' : 'cursor-pointer text-eft'} border border-eft`} onClick={() => setHideNerdStats(!hideNerdStats)}>
                                 Debug
+                            </button>
+                            <button className={`text-xs p-1 text-sm cursor-pointer ${showBehavior ? 'bg-eft text-black ' : 'cursor-pointer text-eft'} border border-eft`} onClick={() => setShowBehavior(!showBehavior)}>
+                                Behavior
                             </button>
                         </div>
                     </div>

--- a/Private/src/helpers/botBehavior.ts
+++ b/Private/src/helpers/botBehavior.ts
@@ -1,0 +1,98 @@
+export interface BehaviorCategory {
+    key: string
+    label: string
+    color: string
+}
+
+export const BEHAVIOR_CATEGORIES: Record<string, BehaviorCategory> = {
+    combat:   { key: 'combat',   label: 'Combat',   color: '#EF4444' },
+    search:   { key: 'search',   label: 'Search',   color: '#F59E0B' },
+    movement: { key: 'movement', label: 'Movement', color: '#3B82F6' },
+    patrol:   { key: 'patrol',   label: 'Patrol',   color: '#22C55E' },
+    medical:  { key: 'medical',  label: 'Medical',  color: '#EC4899' },
+    loot:     { key: 'loot',     label: 'Loot',     color: '#FACC15' },
+    flee:     { key: 'flee',     label: 'Flee',     color: '#A855F7' },
+    extract:  { key: 'extract',  label: 'Extract',  color: '#06B6D4' },
+    grenade:  { key: 'grenade',  label: 'Grenade',  color: '#FF6B6B' },
+    other:    { key: 'other',    label: 'Other',    color: '#6B7280' },
+}
+
+const DECISION_TO_CATEGORY: Record<string, string> = {
+    // ── Vanilla BotLogicDecision ──
+    // Combat
+    shootFromPlace: 'combat', shootFromCover: 'combat', shootToSmoke: 'combat',
+    dogFight: 'combat', suppressFire: 'combat', suppressGrenade: 'combat', suppressStationary: 'combat',
+    attackMoving: 'combat', attackMovingWithSuppress: 'combat', attackMovingFlank: 'combat',
+    axeTarget: 'combat', oneMeleeAttack: 'combat', grenadeSuicide: 'combat',
+    runToStationary: 'combat', shootFromStationary: 'combat',
+    // Search
+    search: 'search',
+    // Movement
+    goToPoint: 'movement', goToPointTactical: 'movement',
+    goToCoverPoint: 'movement', goToCoverPointTactical: 'movement',
+    runToCover: 'movement', runToCoverZigZag: 'movement', teleportToCover: 'movement',
+    holdPosition: 'movement',
+    goToEnemy: 'movement', goToEnemyZigZag: 'movement',
+    runToEnemy: 'movement', runToEnemyZigZag: 'movement',
+    // Patrol
+    simplePatrol: 'patrol', followerPatrol: 'patrol', alternativePatrol: 'patrol',
+    standBy: 'patrol', peaceful: 'patrol', peaceLook: 'patrol', peaceHardAim: 'patrol',
+    // Medical
+    heal: 'medical', healStimulators: 'medical', eatDrink: 'medical',
+    repairMalfunction: 'medical', healAnotherTarget: 'medical',
+    // Loot
+    botTakeItem: 'loot', botDropItem: 'loot', deadBody: 'loot', goToLootPointNode: 'loot',
+    // Flee
+    runAwayGrenade: 'flee', runAwayArtillery: 'flee', runAwayBTR: 'flee',
+    flashed: 'flee', panicSitting: 'flee', turnAwayLight: 'flee',
+    // Extract
+    goToExfiltrationPointNode: 'extract', leaveMap: 'extract',
+    // Grenade
+    throwGrenadeFromPlace: 'grenade', runAndThrowGrenadeFromPlace: 'grenade',
+    // Other
+    doorOpen: 'other', warnPlayer: 'other', friendlyTilt: 'other', gesture: 'other',
+    crawl: 'other', moveStealthy: 'other', lay: 'other', watchSecondWeapon: 'other',
+    summon: 'other', followPlayer: 'other', followMeRequest: 'other',
+    plantMine: 'other', deactivateMine: 'other',
+    khorovodChristmasEvent: 'other', doGiftChristmasEvent: 'other',
+
+    // ── SAIN ECombatDecision ──
+    MoveToEngage: 'combat', StandAndShoot: 'combat', ShootDistantEnemy: 'combat',
+    DogFight: 'combat', RushEnemy: 'combat', MeleeAttack: 'combat',
+    FightZombies: 'combat', Freeze: 'combat',
+    Search: 'search',
+    SeekCover: 'movement', ShiftCover: 'movement', Retreat: 'movement',
+    ThrowGrenade: 'grenade',
+
+    // ── SAIN ESquadDecision ──
+    PushSuppressedEnemy: 'combat', GroupSearch: 'search', Suppress: 'combat',
+    Help: 'movement', Regroup: 'movement',
+
+    // ── SAIN ESelfActionType ──
+    Reload: 'medical', FirstAid: 'medical', Surgery: 'medical', Stims: 'medical',
+
+    // ── SAIN ESAINLayer (fallback broad categories) ──
+    Combat: 'combat', Squad: 'combat', Extract: 'extract',
+    Run: 'flee', Peace: 'patrol', AvoidThreat: 'flee',
+
+    // ── BigBrain numeric layer IDs (fallback if SAIN reflection fails) ──
+    '9000': 'other',        // SAIN DebugLayer
+    '9001': 'flee',         // SAIN AvoidThreatLayer
+    '9002': 'extract',      // SAIN ExtractLayer
+    '9003': 'combat',       // SAIN CombatSquadLayer
+    '9004': 'combat',       // SAIN CombatSoloLayer
+}
+
+export function getBehaviorCategory(decision: string | undefined | null): BehaviorCategory | null {
+    if (!decision || decision === '') return null
+    const cleanDecision = decision.startsWith('SAIN:') ? decision.substring(5) : decision
+    const categoryKey = DECISION_TO_CATEGORY[cleanDecision] ?? 'other'
+    return BEHAVIOR_CATEGORIES[categoryKey]
+}
+
+export function formatDecisionLabel(decision: string | undefined | null): string {
+    if (!decision || decision === '') return ''
+    const clean = decision.startsWith('SAIN:') ? decision.substring(5) : decision
+    // Convert camelCase to readable: "shootFromPlace" -> "Shoot From Place"
+    return clean.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase()).trim()
+}

--- a/Private/src/helpers/botBehavior.ts
+++ b/Private/src/helpers/botBehavior.ts
@@ -14,6 +14,7 @@ export const BEHAVIOR_CATEGORIES: Record<string, BehaviorCategory> = {
     flee:     { key: 'flee',     label: 'Flee',     color: '#A855F7' },
     extract:  { key: 'extract',  label: 'Extract',  color: '#06B6D4' },
     grenade:  { key: 'grenade',  label: 'Grenade',  color: '#FF6B6B' },
+    idle:     { key: 'idle',     label: 'Idle',     color: '#374151' },
     other:    { key: 'other',    label: 'Other',    color: '#6B7280' },
 }
 
@@ -39,7 +40,7 @@ const DECISION_TO_CATEGORY: Record<string, string> = {
     standBy: 'patrol', peaceful: 'patrol', peaceLook: 'patrol', peaceHardAim: 'patrol',
     // Medical
     heal: 'medical', healStimulators: 'medical', eatDrink: 'medical',
-    repairMalfunction: 'medical', healAnotherTarget: 'medical',
+    repairMalfunction: 'other', healAnotherTarget: 'medical',
     // Loot
     botTakeItem: 'loot', botDropItem: 'loot', deadBody: 'loot', goToLootPointNode: 'loot',
     // Flee
@@ -69,22 +70,22 @@ const DECISION_TO_CATEGORY: Record<string, string> = {
     Help: 'movement', Regroup: 'movement',
 
     // ── SAIN ESelfActionType ──
-    Reload: 'medical', FirstAid: 'medical', Surgery: 'medical', Stims: 'medical',
+    Reload: 'other', FirstAid: 'medical', Surgery: 'medical', Stims: 'medical',
 
     // ── SAIN ESAINLayer (fallback broad categories) ──
     Combat: 'combat', Squad: 'combat', Extract: 'extract',
     Run: 'flee', Peace: 'patrol', AvoidThreat: 'flee',
 
     // ── BigBrain numeric layer IDs (fallback if SAIN reflection fails) ──
-    '9000': 'other',        // SAIN DebugLayer
+    '9000': 'idle',         // SAIN DebugLayer (default/inactive)
     '9001': 'flee',         // SAIN AvoidThreatLayer
     '9002': 'extract',      // SAIN ExtractLayer
     '9003': 'combat',       // SAIN CombatSquadLayer
     '9004': 'combat',       // SAIN CombatSoloLayer
 }
 
-export function getBehaviorCategory(decision: string | undefined | null): BehaviorCategory | null {
-    if (!decision || decision === '') return null
+export function getBehaviorCategory(decision: string | undefined | null): BehaviorCategory {
+    if (!decision || decision === '') return BEHAVIOR_CATEGORIES.idle
     const cleanDecision = decision.startsWith('SAIN:') ? decision.substring(5) : decision
     const categoryKey = DECISION_TO_CATEGORY[cleanDecision] ?? 'other'
     return BEHAVIOR_CATEGORIES[categoryKey]

--- a/Private/src/helpers/players.tsx
+++ b/Private/src/helpers/players.tsx
@@ -1,0 +1,149 @@
+import BotMapping from '../assets/botMapping.json'
+
+export const PMC_COLORS = [
+    "#3357FF", "#FFD433", "#33FFF3", "#9370DB", "#BC8F8F",
+    "#FF5733", "#7FFFD4", "#FFFF99", "#ae85f9", "#FF9633",
+    "#3366FF", "#B87333", "#FFA533", "#33FFAF", "#5733FF",
+    "#FF33D4", "#33FFCC", "#FF5733", "#5733FF", "#FFD433",
+    "#B833FF", "#33FF57", "#33FF57", "#660000", "#3399FF",
+    "#FF33B8", "#8CFF33", "#33FFD5", "#FF6F33", "#FF3333",
+    "#FF5733", "#33D4FF", "#FF5733", "#FF3380", "#33FF57",
+    "#33FF57", "#FF33E9", "#FFD433", "#ae85f9", "#FF33D4",
+    "#8D33FF", "#33FFF3", "#FF9633", "#33FF8D", "#FF33A1",
+    "#33FF8D", "#33FFF3",
+]
+
+export function getMarkerLabel(player: any): string | null {
+    const type = (player?.type || '').toUpperCase()
+
+    if (type.includes('KILLA')) return 'Ki'
+    if (type.includes('RASHALA')) return 'Ra'
+    if (type.includes('SHTURMAN')) return 'Sh'
+    if (type.includes('TAGILLA')) return 'Ta'
+    if (type.includes('SANITAR')) return 'Sa'
+    if (type.includes('GLUHAR')) return 'Gl'
+    if (type.includes('ZRYACHIY')) return 'Zr'
+    if (type.includes('KABAN')) return 'Kb'
+    if (type.includes('KOLONTAY')) return 'Ko'
+    if (type.includes('PARTIZAN')) return 'P'
+
+    if (type.includes('KNIGHT')) return 'Kn'
+    if (type.includes('BIGPIPE')) return 'BP'
+    if (type.includes('BIRDEYE')) return 'BE'
+
+    if (type.includes('MERCENARY')) return 'M'
+    if (type.includes('RUAF')) return 'R'
+    if (type.includes('UNTAR')) return 'U'
+    if (type.includes('BLACK DIV')) return 'BD'
+
+    if (type.includes('SHADOW TAGILLA')) return 'ST'
+    if (type.includes('VENGEFUL KILLA')) return 'VK'
+    if (type.includes('INFECTED')) return 'If'
+    if (type.includes('SPIRIT')) return 'Sp'
+
+    if (type.includes('RAIDER')) return 'Rd'
+    if (type.includes('ROGUE')) return 'Rg'
+    if (type.includes('CULTIST PRIEST')) return 'CP'
+    if (type.includes('CULTIST')) return 'Cu'
+    if (type.includes('BLOODHOUND')) return 'Bh'
+    if (type.includes('BTR')) return 'BTR_ICON'
+    if (type.includes('SNIPER')) return 'Sn'
+
+    return null
+}
+
+export function getPlayerColor(player: any, index: number): string {
+    if (player === undefined) return '#999'
+
+    let botMapping = (BotMapping as any)[player.type]
+    if (player.name === 'Knight') {
+        botMapping = { type: 'GOON' }
+    }
+    if (!botMapping) {
+        botMapping = { type: 'UNKNOWN' }
+    }
+
+    switch (botMapping.type) {
+        case 'SCAV': return '#33FF57'
+        case 'BOSS': return '#FF0000'
+        case 'ROGUE':
+        case 'FOLLOWER': return '#ff7b00'
+        case 'BLOODHOUND': return '#6d0000'
+        case 'RAIDER': return '#FF00FF'
+        case 'PLAYER_SCAV': return '#33FF8D'
+        case 'SNIPER': return '#00911a'
+        case 'GOON': return '#ff005d'
+        case 'CULT': return '#6f00ff'
+        case 'OTHER': return '#00eeff'
+        case 'MERCENARY': return '#FFD700'
+        case 'RUAF': return '#4A90D9'
+        case 'UNTAR': return '#00BFFF'
+        case 'BLACKDIV': return '#555555'
+        case 'INFECTED': return '#7FFF00'
+        default:
+            if (player.type === 'PLAYER' && player.team === 'Savage') return '#33FF57'
+            return PMC_COLORS[(player.group ?? index) % PMC_COLORS.length]
+    }
+}
+
+export function getLegendIcon(player: any, color: string, pmcIdx?: number): JSX.Element {
+    const label = getMarkerLabel(player)
+    if (label === 'BTR_ICON') {
+        return <span style={{ width: '24px', height: '18px', marginRight: '4px', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}><svg viewBox="0 0 24 18" width="24" height="18" fill="none"><rect x="2" y="3" width="20" height="8" rx="1" fill={color}/><rect x="5" y="1" width="10" height="4" rx="1" fill={color}/><line x1="15" y1="3" x2="20" y2="5" stroke={color} strokeWidth="1.2"/><circle cx="5.5" cy="13.5" r="2.5" fill={color}/><circle cx="12" cy="13.5" r="2.5" fill={color}/><circle cx="18.5" cy="13.5" r="2.5" fill={color}/><circle cx="5.5" cy="13.5" r="1" fill="#1a1a1a"/><circle cx="12" cy="13.5" r="1" fill="#1a1a1a"/><circle cx="18.5" cy="13.5" r="1" fill="#1a1a1a"/></svg></span>
+    }
+    if (label) {
+        return <span style={{ width: '18px', height: '18px', borderRadius: '2px', marginRight: '6px', background: color, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: '9px', fontWeight: 'bold', color: '#fff', textShadow: '0 0 2px rgba(0,0,0,0.9)', border: '1px solid rgba(255,255,255,0.6)', flexShrink: 0, lineHeight: 1 }}>{label}</span>
+    }
+    if (pmcIdx !== undefined) {
+        return <span style={{ width: '18px', height: '18px', borderRadius: '50%', marginRight: '6px', background: color, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: '9px', fontWeight: 'bold', color: '#fff', textShadow: '0 0 2px rgba(0,0,0,0.9)', border: '1px solid rgba(255,255,255,0.6)', flexShrink: 0, lineHeight: 1 }}>{pmcIdx}</span>
+    }
+    return <span style={{ width: '10px', height: '10px', minWidth: '10px', minHeight: '10px', borderRadius: '50%', marginRight: '6px', background: color, border: '1px solid rgba(255,255,255,0.4)', flexShrink: 0, display: 'inline-block' }}></span>
+}
+
+export function getPlayerFaction(player: any): string {
+    if (player === undefined) return 'Unknown'
+
+    if (player.team === 'Usec' || player.team === 'Bear') return 'PMC'
+    if (player.type === 'PLAYER' && player.team === 'Savage') return 'Player Scav'
+    if (player.type === 'HUMAN') return 'PMC'
+
+    let botMapping = (BotMapping as any)[player.type]
+    if (player.name === 'Knight') botMapping = { type: 'GOON' }
+    if (!botMapping) return 'Unknown'
+
+    switch (botMapping.type) {
+        case 'SCAV': return 'Scav'
+        case 'BOSS': return 'Boss'
+        case 'ROGUE': return 'Rogue'
+        case 'FOLLOWER': return 'Follower'
+        case 'BLOODHOUND': return 'Bloodhound'
+        case 'RAIDER': return 'Raider'
+        case 'PLAYER_SCAV': return 'Player Scav'
+        case 'SNIPER': return 'Sniper'
+        case 'GOON': return 'Goon'
+        case 'CULT': return 'Cultist'
+        case 'OTHER': return 'Other'
+        case 'MERCENARY': return 'Mercenary'
+        case 'RUAF': return 'RUAF'
+        case 'UNTAR': return 'UNTAR'
+        case 'BLACKDIV': return 'Black Div'
+        case 'INFECTED': return 'Infected'
+        default: return 'Unknown'
+    }
+}
+
+export function buildPmcIndexMap(players: any[]): Record<string, number> {
+    const map: Record<string, number> = {}
+    const groupCounters: Record<number, number> = {}
+    for (const p of players) {
+        const isPMC = p.team === 'Usec' || p.team === 'Bear'
+        const isHuman = p.type === 'HUMAN'
+        if (isPMC || isHuman) {
+            const group = p.group ?? 0
+            if (groupCounters[group] === undefined) groupCounters[group] = 0
+            groupCounters[group]++
+            map[p.profileId] = groupCounters[group]
+        }
+    }
+    return map
+}

--- a/Private/src/main.tsx
+++ b/Private/src/main.tsx
@@ -11,6 +11,7 @@ import RaidMap, { loader as RaidMapLoader } from "./pages/V2/RaidMap";
 import RaidCharts from "./pages/V2/RaidCharts";
 import RaidTimeline from "./pages/V2/RaidTimeline";
 import RaidSettings, { loader as RaidSettingsLoader } from "./pages/V2/RaidSettings";
+import RaidBehaviorTimeline, { loader as RaidBehaviorTimelineLoader } from "./pages/V2/RaidBehaviorTimeline";
 
 const v2_routes = [
   {
@@ -44,7 +45,12 @@ const v2_routes = [
             element: <RaidMap />,
             loader: RaidMapLoader
           },
-          { 
+          {
+            path: "/raid/:raidId/behavior",
+            element: <RaidBehaviorTimeline />,
+            loader: RaidBehaviorTimelineLoader
+          },
+          {
             path: "/raid/:raidId/settings",
             element: <RaidSettings />,
             loader: RaidSettingsLoader

--- a/Private/src/pages/V2/Raid.tsx
+++ b/Private/src/pages/V2/Raid.tsx
@@ -24,6 +24,7 @@ export default function Raid() {
               <Link to={`/raid/${raidId}/charts`} className='py-1 px-4 bg-eft text-black hover:opacity-75'>Stats</Link>
               <Link to={`/raid/${raidId}/timeline`} className='py-1 px-4 bg-eft text-black hover:opacity-75'>Timeline</Link>
               <Link to={`/raid/${raidId}/map`} className='py-1 px-4 bg-eft text-black hover:opacity-75'>Map</Link>
+              <Link to={`/raid/${raidId}/behavior`} className='py-1 px-4 bg-eft text-black hover:opacity-75'>Behavior</Link>
           </div>
           <div className="flex gap-2">
               {/* <button className='py-1 px-4 bg-eft text-black hover:opacity-75'>Export</button> */}

--- a/Private/src/pages/V2/RaidBehaviorTimeline.tsx
+++ b/Private/src/pages/V2/RaidBehaviorTimeline.tsx
@@ -180,11 +180,11 @@ export default function RaidBehaviorTimeline() {
             // Only zoom if cursor is over the timeline area (not the name column)
             const rect = el.getBoundingClientRect()
             const relX = e.clientX - rect.left
-            if (relX < 160) return // over the name column
+            if (relX < 180) return // over the name column
 
             e.preventDefault()
-            const timelineWidth = rect.width - 160
-            const pct = Math.max(0, Math.min(1, (relX - 160) / timelineWidth))
+            const timelineWidth = rect.width - 180
+            const pct = Math.max(0, Math.min(1, (relX - 180) / timelineWidth))
 
             const curStart = viewRange?.start ?? raidStart
             const curEnd = viewRange?.end ?? raidEnd
@@ -221,7 +221,7 @@ export default function RaidBehaviorTimeline() {
 
     if (playerRows.length === 0) {
         return (
-            <div className="p-4 text-eft text-center opacity-50">
+            <div className="p-4 text-eft text-center opacity-50" style={{ fontSize: '14px' }}>
                 No behavior data available. Play a raid with the updated 1.0.0 mod to capture bot decisions.
             </div>
         )
@@ -233,7 +233,7 @@ export default function RaidBehaviorTimeline() {
         <div ref={containerRef} className="p-4" style={{ overflowX: 'auto' }}>
             {/* SAIN recommendation banner */}
             {!hasSain && (
-                <div className="mb-3 px-3 py-2" style={{ background: 'rgba(245,158,11,0.12)', border: '1px solid rgba(245,158,11,0.3)', borderRadius: 4, fontSize: '12px', color: '#F59E0B' }}>
+                <div className="mb-3 px-3 py-2" style={{ background: 'rgba(245,158,11,0.12)', border: '1px solid rgba(245,158,11,0.3)', borderRadius: 4, fontSize: '13px', color: '#F59E0B' }}>
                     <strong>SAIN recommended</strong> — Install <a href="https://hub.sp-tarkov.com/files/file/1062-sain-solarint-s-ai-modifications-full-ai-combat-system-replacement/" target="_blank" rel="noreferrer" style={{ color: '#F59E0B', textDecoration: 'underline' }}>SAIN</a> for detailed bot behavior data (Search, StandAndShoot, FirstAid, etc.). Without SAIN, behavior categories are approximate.
                 </div>
             )}
@@ -241,42 +241,42 @@ export default function RaidBehaviorTimeline() {
             {/* Legend + zoom controls */}
             <div className="flex flex-wrap items-center gap-4 mb-4">
                 {Object.values(BEHAVIOR_CATEGORIES).map(cat => (
-                    <div key={cat.key} className="flex items-center gap-1" style={{ fontSize: '11px' }}>
-                        <span style={{ width: 10, height: 10, borderRadius: 2, background: cat.color, display: 'inline-block' }}></span>
+                    <div key={cat.key} className="flex items-center gap-1" style={{ fontSize: '13px' }}>
+                        <span style={{ width: 12, height: 12, borderRadius: 2, background: cat.color, display: 'inline-block' }}></span>
                         <span className="text-eft">{cat.label}</span>
                     </div>
                 ))}
                 {/* Hatched legend items */}
-                <div className="flex items-center gap-1" style={{ fontSize: '11px' }}>
-                    <span className="rr-hatch-prespawn" style={{ width: 10, height: 10, borderRadius: 2, display: 'inline-block', border: '1px solid rgba(154,136,102,0.3)' }}></span>
+                <div className="flex items-center gap-1" style={{ fontSize: '13px' }}>
+                    <span className="rr-hatch-prespawn" style={{ width: 12, height: 12, borderRadius: 2, display: 'inline-block', border: '1px solid rgba(154,136,102,0.3)' }}></span>
                     <span className="text-eft">Pre-spawn</span>
                 </div>
-                <div className="flex items-center gap-1" style={{ fontSize: '11px' }}>
-                    <span className="rr-hatch-dead" style={{ width: 10, height: 10, borderRadius: 2, display: 'inline-block', border: '1px solid rgba(239,68,68,0.3)' }}></span>
+                <div className="flex items-center gap-1" style={{ fontSize: '13px' }}>
+                    <span className="rr-hatch-dead" style={{ width: 12, height: 12, borderRadius: 2, display: 'inline-block', border: '1px solid rgba(239,68,68,0.3)' }}></span>
                     <span className="text-eft">Dead</span>
                 </div>
                 {viewRange && (
-                    <button onClick={resetZoom} className="px-2 py-0.5 text-black bg-eft hover:opacity-75" style={{ fontSize: '10px' }}>
+                    <button onClick={resetZoom} className="px-2 py-0.5 text-black bg-eft hover:opacity-75" style={{ fontSize: '12px' }}>
                         Reset Zoom
                     </button>
                 )}
             </div>
 
             {/* Zoom hint */}
-            <div style={{ fontSize: '9px', color: '#666', marginBottom: 4 }}>
+            <div style={{ fontSize: '11px', color: '#666', marginBottom: 4 }}>
                 Scroll to zoom in/out
             </div>
 
             {/* Time axis */}
             <div className="flex" style={{ marginBottom: 2 }}>
-                <div style={{ width: 160, flexShrink: 0 }}></div>
+                <div style={{ width: 180, flexShrink: 0 }}></div>
                 <div className="relative flex-1" style={{ height: 16 }}>
                     {ticks.map(t => {
                         const left = ((t - effectiveStart) / viewDuration) * 100
                         if (left < 0 || left > 100) return null
                         return (
                             <span key={t} style={{
-                                position: 'absolute', left: `${left}%`, fontSize: '9px',
+                                position: 'absolute', left: `${left}%`, fontSize: '11px',
                                 color: '#9a8866', transform: 'translateX(-50%)', whiteSpace: 'nowrap'
                             }}>
                                 {msToHMS(t)}
@@ -302,9 +302,9 @@ export default function RaidBehaviorTimeline() {
                 }
 
                 return (
-                    <div key={row.profileId} className="flex items-center" style={{ height: 26, marginBottom: 1 }}>
+                    <div key={row.profileId} className="flex items-center" style={{ height: 28, marginBottom: 1 }}>
                         {/* Player name with icon */}
-                        <div className="flex items-center" style={{ width: 160, flexShrink: 0, fontSize: '11px', overflow: 'hidden', whiteSpace: 'nowrap' }}>
+                        <div className="flex items-center" style={{ width: 180, flexShrink: 0, fontSize: '13px', overflow: 'hidden', whiteSpace: 'nowrap' }}>
                             {getLegendIcon(row.player, row.color, row.pmcIdx)}
                             <span className="text-eft" style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
                                 {row.name}
@@ -362,7 +362,7 @@ export default function RaidBehaviorTimeline() {
             {/* Horizontal scroll bar (only when zoomed) */}
             {viewRange && (
                 <div className="flex" style={{ marginTop: 6 }}>
-                    <div style={{ width: 160, flexShrink: 0 }}></div>
+                    <div style={{ width: 180, flexShrink: 0 }}></div>
                     <div className="flex-1" style={{ position: 'relative', height: 16 }}>
                         {/* Track background showing full raid extent */}
                         <div style={{ position: 'absolute', top: 6, left: 0, right: 0, height: 4, background: 'rgba(154,136,102,0.15)', borderRadius: 2 }} />
@@ -436,11 +436,11 @@ export default function RaidBehaviorTimeline() {
                     top: hoveredSegment.y - 10,
                     background: '#1a1a1a',
                     border: '1px solid #9a8866',
-                    padding: '6px 10px',
-                    fontSize: '11px',
+                    padding: '8px 12px',
+                    fontSize: '13px',
                     zIndex: 9999,
                     pointerEvents: 'none',
-                    maxWidth: 300,
+                    maxWidth: 320,
                 }}>
                     <div style={{ color: (hoveredSegment.seg.category === 'idle' || hoveredSegment.seg.category === 'patrol') ? '#9a8866' : hoveredSegment.seg.categoryColor, fontWeight: 'bold' }}>
                         {hoveredSegment.seg.label}
@@ -448,7 +448,7 @@ export default function RaidBehaviorTimeline() {
                     <div style={{ color: '#ccc' }}>
                         {hoveredSegment.seg.decision ? formatDecisionLabel(hoveredSegment.seg.decision) : 'No active decision'}
                     </div>
-                    <div style={{ color: '#999', fontSize: '10px' }}>
+                    <div style={{ color: '#999', fontSize: '12px' }}>
                         {hoveredSegment.playerName} &middot; {msToHMS(hoveredSegment.seg.startTime)} - {msToHMS(hoveredSegment.seg.endTime)}
                         {' '}({((hoveredSegment.seg.endTime - hoveredSegment.seg.startTime) / 1000).toFixed(1)}s)
                     </div>

--- a/Private/src/pages/V2/RaidBehaviorTimeline.tsx
+++ b/Private/src/pages/V2/RaidBehaviorTimeline.tsx
@@ -1,5 +1,5 @@
 import { LoaderFunctionArgs, useLoaderData, useOutletContext } from "react-router-dom";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import api from "../../api/api";
 import { TrackingPositionalData, TrackingRaidData } from "../../types/api_types";
 import { intl, msToHMS } from "../../helpers";
@@ -28,22 +28,16 @@ function buildSegments(entries: TrackingPositionalData[]): BehaviorSegment[] {
     for (const entry of entries) {
         const decision = (entry as any).decision || ''
         const cat = getBehaviorCategory(decision)
-        const catKey = cat?.key ?? ''
 
-        if (!catKey) {
-            if (current) { segments.push(current); current = null }
-            continue
-        }
-
-        if (current && current.category === catKey) {
+        if (current && current.category === cat.key) {
             current.endTime = Number(entry.time)
         } else {
             if (current) segments.push(current)
             current = {
-                category: catKey,
-                categoryColor: cat?.color ?? '#6B7280',
+                category: cat.key,
+                categoryColor: cat.color,
                 decision,
-                label: cat?.label ?? 'Unknown',
+                label: cat.label,
                 startTime: Number(entry.time),
                 endTime: Number(entry.time),
             }
@@ -51,6 +45,35 @@ function buildSegments(entries: TrackingPositionalData[]): BehaviorSegment[] {
     }
     if (current) segments.push(current)
     return segments
+}
+
+// CSS pattern for hatched overlays (injected once)
+const HATCH_STYLE_ID = 'rr-behavior-hatch-styles'
+function ensureHatchStyles() {
+    if (document.getElementById(HATCH_STYLE_ID)) return
+    const style = document.createElement('style')
+    style.id = HATCH_STYLE_ID
+    style.textContent = `
+        .rr-hatch-dead {
+            background: repeating-linear-gradient(
+                -45deg,
+                transparent,
+                transparent 3px,
+                rgba(239,68,68,0.25) 3px,
+                rgba(239,68,68,0.25) 5px
+            ) !important;
+        }
+        .rr-hatch-prespawn {
+            background: repeating-linear-gradient(
+                -45deg,
+                transparent,
+                transparent 3px,
+                rgba(154,136,102,0.15) 3px,
+                rgba(154,136,102,0.15) 5px
+            ) !important;
+        }
+    `
+    document.head.appendChild(style)
 }
 
 export default function RaidBehaviorTimeline() {
@@ -61,15 +84,36 @@ export default function RaidBehaviorTimeline() {
 
     const [hoveredSegment, setHoveredSegment] = useState<{ seg: BehaviorSegment, playerName: string, x: number, y: number } | null>(null);
 
+    // Zoom state: viewStart/viewEnd as ms timestamps (null = full range)
+    const [viewRange, setViewRange] = useState<{ start: number, end: number } | null>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    // Build death time lookup from kills data
+    const deathTimes = useMemo(() => {
+        const map: Record<string, number> = {}
+        if (raid?.kills) {
+            for (const k of raid.kills) {
+                if (k.killedId && k.time != null) {
+                    // Keep earliest death time per player
+                    if (!(k.killedId in map) || k.time < map[k.killedId]) {
+                        map[k.killedId] = k.time
+                    }
+                }
+            }
+        }
+        return map
+    }, [raid?.kills])
+
     const data = useMemo(() => {
         if (!positions || !raid?.players) return { players: [] as any[], raidStart: 0, raidEnd: 0 }
 
         let raidStart = Infinity, raidEnd = 0
-        const playerRows: { profileId: string, name: string, player: any, color: string, segments: BehaviorSegment[], pmcIdx?: number }[] = []
+        const playerRows: { profileId: string, name: string, player: any, color: string, segments: BehaviorSegment[], pmcIdx?: number, spawnTime: number, deathTime: number | null }[] = []
 
         for (const p of raid.players) {
-            // Skip BTR
+            // Skip BTR and human players (only show bots)
             if (p.type?.includes('BTR')) continue
+            if (p.type === 'HUMAN') continue
             const entries = positions[p.profileId]
             if (!entries || entries.length === 0) continue
 
@@ -90,28 +134,90 @@ export default function RaidBehaviorTimeline() {
                 color: getPlayerColor(p, idx),
                 segments,
                 pmcIdx: pmcIndexMap[p.profileId],
+                spawnTime: p.spawnTime,
+                deathTime: deathTimes[p.profileId] ?? null,
             })
         }
 
-        // Sort: PMCs first, then by name
+        // Sort by team/side, then by name
+        const teamOrder: Record<string, number> = { 'Usec': 0, 'Bear': 1, 'Savage': 2 }
         playerRows.sort((a, b) => {
-            const aIsPMC = a.player.team === 'Usec' || a.player.team === 'Bear'
-            const bIsPMC = b.player.team === 'Usec' || b.player.team === 'Bear'
-            if (aIsPMC !== bIsPMC) return aIsPMC ? -1 : 1
+            const aOrder = teamOrder[a.player.team] ?? 3
+            const bOrder = teamOrder[b.player.team] ?? 3
+            if (aOrder !== bOrder) return aOrder - bOrder
             return a.name.localeCompare(b.name)
         })
 
         return { players: playerRows, raidStart, raidEnd }
-    }, [positions, raid, intl_dir, pmcIndexMap])
+    }, [positions, raid, intl_dir, pmcIndexMap, deathTimes])
 
     const { players: playerRows, raidStart, raidEnd } = data
-    const raidDuration = raidEnd - raidStart || 1
 
-    // Time axis ticks (every 60 seconds)
+    // Effective view range (zoom or full)
+    const effectiveStart = viewRange?.start ?? raidStart
+    const effectiveEnd = viewRange?.end ?? raidEnd
+    const viewDuration = effectiveEnd - effectiveStart || 1
+
+    // Time axis ticks — adapt interval to zoom level
     const ticks: number[] = []
-    for (let t = raidStart; t <= raidEnd; t += 60000) {
+    const durationSec = viewDuration / 1000
+    const tickInterval = durationSec <= 60 ? 10000 : durationSec <= 300 ? 30000 : 60000
+    const firstTick = Math.ceil(effectiveStart / tickInterval) * tickInterval
+    for (let t = firstTick; t <= effectiveEnd; t += tickInterval) {
         ticks.push(t)
     }
+
+    // Ensure hatch CSS exists
+    useMemo(() => ensureHatchStyles(), [])
+
+    const resetZoom = useCallback(() => setViewRange(null), [])
+
+    // Scroll-to-zoom: wheel zooms in/out centered on cursor position
+    useEffect(() => {
+        const el = containerRef.current
+        if (!el) return
+        const handler = (e: WheelEvent) => {
+            // Only zoom if cursor is over the timeline area (not the name column)
+            const rect = el.getBoundingClientRect()
+            const relX = e.clientX - rect.left
+            if (relX < 160) return // over the name column
+
+            e.preventDefault()
+            const timelineWidth = rect.width - 160
+            const pct = Math.max(0, Math.min(1, (relX - 160) / timelineWidth))
+
+            const curStart = viewRange?.start ?? raidStart
+            const curEnd = viewRange?.end ?? raidEnd
+            const curDuration = curEnd - curStart
+            const cursorTime = curStart + pct * curDuration
+
+            const zoomFactor = e.deltaY > 0 ? 1.3 : 0.7 // scroll down = zoom out, up = zoom in
+            const newDuration = curDuration * zoomFactor
+            const fullDuration = raidEnd - raidStart
+
+            // Don't zoom beyond full range
+            if (newDuration >= fullDuration) {
+                setViewRange(null)
+                return
+            }
+            // Don't zoom below 5 seconds
+            if (newDuration < 5000) return
+
+            // Keep cursor at same relative position
+            let newStart = cursorTime - pct * newDuration
+            let newEnd = cursorTime + (1 - pct) * newDuration
+
+            // Clamp to raid bounds
+            if (newStart < raidStart) { newEnd += raidStart - newStart; newStart = raidStart }
+            if (newEnd > raidEnd) { newStart -= newEnd - raidEnd; newEnd = raidEnd }
+            newStart = Math.max(newStart, raidStart)
+            newEnd = Math.min(newEnd, raidEnd)
+
+            setViewRange({ start: newStart, end: newEnd })
+        }
+        el.addEventListener('wheel', handler, { passive: false })
+        return () => el.removeEventListener('wheel', handler)
+    }, [viewRange, raidStart, raidEnd])
 
     if (playerRows.length === 0) {
         return (
@@ -124,7 +230,7 @@ export default function RaidBehaviorTimeline() {
     const hasSain = !!raid?.detectedMods?.match(/SAIN/gi)
 
     return (
-        <div className="p-4" style={{ overflowX: 'auto' }}>
+        <div ref={containerRef} className="p-4" style={{ overflowX: 'auto' }}>
             {/* SAIN recommendation banner */}
             {!hasSain && (
                 <div className="mb-3 px-3 py-2" style={{ background: 'rgba(245,158,11,0.12)', border: '1px solid rgba(245,158,11,0.3)', borderRadius: 4, fontSize: '12px', color: '#F59E0B' }}>
@@ -132,14 +238,33 @@ export default function RaidBehaviorTimeline() {
                 </div>
             )}
 
-            {/* Legend */}
-            <div className="flex flex-wrap gap-4 mb-4">
+            {/* Legend + zoom controls */}
+            <div className="flex flex-wrap items-center gap-4 mb-4">
                 {Object.values(BEHAVIOR_CATEGORIES).map(cat => (
                     <div key={cat.key} className="flex items-center gap-1" style={{ fontSize: '11px' }}>
                         <span style={{ width: 10, height: 10, borderRadius: 2, background: cat.color, display: 'inline-block' }}></span>
                         <span className="text-eft">{cat.label}</span>
                     </div>
                 ))}
+                {/* Hatched legend items */}
+                <div className="flex items-center gap-1" style={{ fontSize: '11px' }}>
+                    <span className="rr-hatch-prespawn" style={{ width: 10, height: 10, borderRadius: 2, display: 'inline-block', border: '1px solid rgba(154,136,102,0.3)' }}></span>
+                    <span className="text-eft">Pre-spawn</span>
+                </div>
+                <div className="flex items-center gap-1" style={{ fontSize: '11px' }}>
+                    <span className="rr-hatch-dead" style={{ width: 10, height: 10, borderRadius: 2, display: 'inline-block', border: '1px solid rgba(239,68,68,0.3)' }}></span>
+                    <span className="text-eft">Dead</span>
+                </div>
+                {viewRange && (
+                    <button onClick={resetZoom} className="px-2 py-0.5 text-black bg-eft hover:opacity-75" style={{ fontSize: '10px' }}>
+                        Reset Zoom
+                    </button>
+                )}
+            </div>
+
+            {/* Zoom hint */}
+            <div style={{ fontSize: '9px', color: '#666', marginBottom: 4 }}>
+                Scroll to zoom in/out
             </div>
 
             {/* Time axis */}
@@ -147,7 +272,8 @@ export default function RaidBehaviorTimeline() {
                 <div style={{ width: 160, flexShrink: 0 }}></div>
                 <div className="relative flex-1" style={{ height: 16 }}>
                     {ticks.map(t => {
-                        const left = ((t - raidStart) / raidDuration) * 100
+                        const left = ((t - effectiveStart) / viewDuration) * 100
+                        if (left < 0 || left > 100) return null
                         return (
                             <span key={t} style={{
                                 position: 'absolute', left: `${left}%`, fontSize: '9px',
@@ -161,42 +287,146 @@ export default function RaidBehaviorTimeline() {
             </div>
 
             {/* Player rows */}
-            {playerRows.map(row => (
-                <div key={row.profileId} className="flex items-center" style={{ height: 26, marginBottom: 1 }}>
-                    {/* Player name with icon */}
-                    <div className="flex items-center" style={{ width: 160, flexShrink: 0, fontSize: '11px', overflow: 'hidden', whiteSpace: 'nowrap' }}>
-                        {getLegendIcon(row.player, row.color, row.pmcIdx)}
-                        <span className="text-eft" style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                            {row.name}
-                        </span>
+            {playerRows.map(row => {
+                // Pre-spawn hatched zone (before first position data)
+                const firstDataTime = row.segments.length > 0 ? row.segments[0].startTime : effectiveEnd
+                const preSpawnLeft = 0
+                const preSpawnWidth = Math.max(0, ((Math.min(firstDataTime, effectiveEnd) - effectiveStart) / viewDuration) * 100)
+
+                // Death hatched zone (after death to end of view)
+                const deathTime = row.deathTime
+                let deathLeft = 0, deathWidth = 0
+                if (deathTime != null && deathTime < effectiveEnd) {
+                    deathLeft = Math.max(0, ((deathTime - effectiveStart) / viewDuration) * 100)
+                    deathWidth = Math.max(0, 100 - deathLeft)
+                }
+
+                return (
+                    <div key={row.profileId} className="flex items-center" style={{ height: 26, marginBottom: 1 }}>
+                        {/* Player name with icon */}
+                        <div className="flex items-center" style={{ width: 160, flexShrink: 0, fontSize: '11px', overflow: 'hidden', whiteSpace: 'nowrap' }}>
+                            {getLegendIcon(row.player, row.color, row.pmcIdx)}
+                            <span className="text-eft" style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                                {row.name}
+                            </span>
+                        </div>
+                        {/* Segments bar */}
+                        <div className="relative flex-1" style={{ height: 20, background: 'rgba(154,136,102,0.08)', borderRadius: 2, overflow: 'hidden' }}>
+                            {/* Pre-spawn hatched area */}
+                            {preSpawnWidth > 0.1 && (
+                                <div className="rr-hatch-prespawn" style={{
+                                    position: 'absolute', left: `${preSpawnLeft}%`, width: `${preSpawnWidth}%`,
+                                    height: '100%', zIndex: 1,
+                                }} />
+                            )}
+                            {/* Behavior segments */}
+                            {row.segments.map((seg: BehaviorSegment, i: number) => {
+                                const segStart = Math.max(seg.startTime, effectiveStart)
+                                const segEnd = Math.min(seg.endTime, effectiveEnd)
+                                if (segStart >= effectiveEnd || segEnd <= effectiveStart) return null
+                                const left = ((segStart - effectiveStart) / viewDuration) * 100
+                                const width = ((segEnd - segStart) / viewDuration) * 100
+                                const isPassive = seg.category === 'idle' || seg.category === 'patrol'
+                                return (
+                                    <div
+                                        key={i}
+                                        style={{
+                                            position: 'absolute',
+                                            left: `${left}%`,
+                                            width: `${Math.max(width, 0.2)}%`,
+                                            height: '100%',
+                                            background: isPassive ? 'rgba(154,136,102,0.12)' : seg.categoryColor,
+                                            opacity: isPassive ? 0.5 : 0.85,
+                                            borderRadius: 1,
+                                            cursor: 'pointer',
+                                            zIndex: 2,
+                                        }}
+                                        onMouseEnter={(e) => setHoveredSegment({ seg, playerName: row.name, x: e.clientX, y: e.clientY })}
+                                        onMouseMove={(e) => setHoveredSegment(prev => prev ? { ...prev, x: e.clientX, y: e.clientY } : null)}
+                                        onMouseLeave={() => setHoveredSegment(null)}
+                                    />
+                                )
+                            })}
+                            {/* Death hatched area */}
+                            {deathWidth > 0.1 && (
+                                <div className="rr-hatch-dead" style={{
+                                    position: 'absolute', left: `${deathLeft}%`, width: `${deathWidth}%`,
+                                    height: '100%', zIndex: 3,
+                                }} />
+                            )}
+                        </div>
                     </div>
-                    {/* Segments bar */}
-                    <div className="relative flex-1" style={{ height: 20, background: 'rgba(154,136,102,0.08)', borderRadius: 2 }}>
-                        {row.segments.map((seg: BehaviorSegment, i: number) => {
-                            const left = ((seg.startTime - raidStart) / raidDuration) * 100
-                            const width = ((seg.endTime - seg.startTime) / raidDuration) * 100
+                )
+            })}
+
+            {/* Horizontal scroll bar (only when zoomed) */}
+            {viewRange && (
+                <div className="flex" style={{ marginTop: 6 }}>
+                    <div style={{ width: 160, flexShrink: 0 }}></div>
+                    <div className="flex-1" style={{ position: 'relative', height: 16 }}>
+                        {/* Track background showing full raid extent */}
+                        <div style={{ position: 'absolute', top: 6, left: 0, right: 0, height: 4, background: 'rgba(154,136,102,0.15)', borderRadius: 2 }} />
+                        {/* Thumb showing current view window */}
+                        {(() => {
+                            const fullDuration = raidEnd - raidStart || 1
+                            const thumbLeft = ((effectiveStart - raidStart) / fullDuration) * 100
+                            const thumbWidth = Math.max(((effectiveEnd - effectiveStart) / fullDuration) * 100, 2)
                             return (
                                 <div
-                                    key={i}
                                     style={{
-                                        position: 'absolute',
-                                        left: `${left}%`,
-                                        width: `${Math.max(width, 0.2)}%`,
-                                        height: '100%',
-                                        background: seg.categoryColor,
-                                        opacity: 0.85,
-                                        borderRadius: 1,
-                                        cursor: 'pointer',
+                                        position: 'absolute', top: 3, height: 10, borderRadius: 3,
+                                        left: `${thumbLeft}%`, width: `${thumbWidth}%`,
+                                        background: 'rgba(154,136,102,0.5)', cursor: 'grab',
+                                        border: '1px solid rgba(154,136,102,0.7)',
+                                        zIndex: 2,
                                     }}
-                                    onMouseEnter={(e) => setHoveredSegment({ seg, playerName: row.name, x: e.clientX, y: e.clientY })}
-                                    onMouseMove={(e) => setHoveredSegment(prev => prev ? { ...prev, x: e.clientX, y: e.clientY } : null)}
-                                    onMouseLeave={() => setHoveredSegment(null)}
+                                    onMouseDown={(e) => {
+                                        if (e.button !== 0) return
+                                        e.preventDefault()
+                                        const startX = e.clientX
+                                        const startRange = { ...viewRange }
+                                        const parentRect = (e.currentTarget.parentElement as HTMLElement).getBoundingClientRect()
+                                        const pxPerMs = parentRect.width / fullDuration
+
+                                        const onMove = (me: MouseEvent) => {
+                                            const dx = me.clientX - startX
+                                            const dtMs = dx / pxPerMs
+                                            let newStart = startRange.start + dtMs
+                                            let newEnd = startRange.end + dtMs
+                                            // Clamp
+                                            if (newStart < raidStart) { newEnd += raidStart - newStart; newStart = raidStart }
+                                            if (newEnd > raidEnd) { newStart -= newEnd - raidEnd; newEnd = raidEnd }
+                                            setViewRange({ start: Math.max(newStart, raidStart), end: Math.min(newEnd, raidEnd) })
+                                        }
+                                        const onUp = () => {
+                                            document.removeEventListener('mousemove', onMove)
+                                            document.removeEventListener('mouseup', onUp)
+                                        }
+                                        document.addEventListener('mousemove', onMove)
+                                        document.addEventListener('mouseup', onUp)
+                                    }}
                                 />
                             )
-                        })}
+                        })()}
+                        {/* Click on track to jump */}
+                        <div
+                            style={{ position: 'absolute', top: 0, left: 0, right: 0, height: '100%', cursor: 'pointer' }}
+                            onClick={(e) => {
+                                const rect = e.currentTarget.getBoundingClientRect()
+                                const pct = (e.clientX - rect.left) / rect.width
+                                const fullDuration = raidEnd - raidStart || 1
+                                const clickTime = raidStart + pct * fullDuration
+                                const halfView = viewDuration / 2
+                                let newStart = clickTime - halfView
+                                let newEnd = clickTime + halfView
+                                if (newStart < raidStart) { newEnd += raidStart - newStart; newStart = raidStart }
+                                if (newEnd > raidEnd) { newStart -= newEnd - raidEnd; newEnd = raidEnd }
+                                setViewRange({ start: Math.max(newStart, raidStart), end: Math.min(newEnd, raidEnd) })
+                            }}
+                        />
                     </div>
                 </div>
-            ))}
+            )}
 
             {/* Hover tooltip */}
             {hoveredSegment && (
@@ -212,11 +442,11 @@ export default function RaidBehaviorTimeline() {
                     pointerEvents: 'none',
                     maxWidth: 300,
                 }}>
-                    <div style={{ color: hoveredSegment.seg.categoryColor, fontWeight: 'bold' }}>
+                    <div style={{ color: (hoveredSegment.seg.category === 'idle' || hoveredSegment.seg.category === 'patrol') ? '#9a8866' : hoveredSegment.seg.categoryColor, fontWeight: 'bold' }}>
                         {hoveredSegment.seg.label}
                     </div>
                     <div style={{ color: '#ccc' }}>
-                        {formatDecisionLabel(hoveredSegment.seg.decision)}
+                        {hoveredSegment.seg.decision ? formatDecisionLabel(hoveredSegment.seg.decision) : 'No active decision'}
                     </div>
                     <div style={{ color: '#999', fontSize: '10px' }}>
                         {hoveredSegment.playerName} &middot; {msToHMS(hoveredSegment.seg.startTime)} - {msToHMS(hoveredSegment.seg.endTime)}

--- a/Private/src/pages/V2/RaidBehaviorTimeline.tsx
+++ b/Private/src/pages/V2/RaidBehaviorTimeline.tsx
@@ -1,0 +1,229 @@
+import { LoaderFunctionArgs, useLoaderData, useOutletContext } from "react-router-dom";
+import { useMemo, useState } from "react";
+import api from "../../api/api";
+import { TrackingPositionalData, TrackingRaidData } from "../../types/api_types";
+import { intl, msToHMS } from "../../helpers";
+import { getPlayerColor, getLegendIcon, buildPmcIndexMap } from "../../helpers/players";
+import { getBehaviorCategory, BEHAVIOR_CATEGORIES, formatDecisionLabel } from "../../helpers/botBehavior";
+import cyr_to_en from '../../assets/cyr_to_en.json';
+
+export async function loader(loaderData: LoaderFunctionArgs) {
+    const positions = await api.getRaidPositionalData(loaderData.params.raidId as string) || [];
+    return { positions };
+}
+
+interface BehaviorSegment {
+    category: string
+    categoryColor: string
+    decision: string
+    label: string
+    startTime: number
+    endTime: number
+}
+
+function buildSegments(entries: TrackingPositionalData[]): BehaviorSegment[] {
+    const segments: BehaviorSegment[] = []
+    let current: BehaviorSegment | null = null
+
+    for (const entry of entries) {
+        const decision = (entry as any).decision || ''
+        const cat = getBehaviorCategory(decision)
+        const catKey = cat?.key ?? ''
+
+        if (!catKey) {
+            if (current) { segments.push(current); current = null }
+            continue
+        }
+
+        if (current && current.category === catKey) {
+            current.endTime = Number(entry.time)
+        } else {
+            if (current) segments.push(current)
+            current = {
+                category: catKey,
+                categoryColor: cat?.color ?? '#6B7280',
+                decision,
+                label: cat?.label ?? 'Unknown',
+                startTime: Number(entry.time),
+                endTime: Number(entry.time),
+            }
+        }
+    }
+    if (current) segments.push(current)
+    return segments
+}
+
+export default function RaidBehaviorTimeline() {
+    const { positions } = useLoaderData() as { positions: Record<string, TrackingPositionalData[]> };
+    const { raid, intl: intl_dir_ot } = useOutletContext() as { raid: TrackingRaidData, intl: { [key: string]: string } };
+    const intl_dir: Record<string, string> = useMemo(() => ({ ...intl_dir_ot, ...cyr_to_en }), [intl_dir_ot]);
+    const pmcIndexMap = useMemo(() => raid?.players ? buildPmcIndexMap(raid.players) : {}, [raid?.players]);
+
+    const [hoveredSegment, setHoveredSegment] = useState<{ seg: BehaviorSegment, playerName: string, x: number, y: number } | null>(null);
+
+    const data = useMemo(() => {
+        if (!positions || !raid?.players) return { players: [] as any[], raidStart: 0, raidEnd: 0 }
+
+        let raidStart = Infinity, raidEnd = 0
+        const playerRows: { profileId: string, name: string, player: any, color: string, segments: BehaviorSegment[], pmcIdx?: number }[] = []
+
+        for (const p of raid.players) {
+            // Skip BTR
+            if (p.type?.includes('BTR')) continue
+            const entries = positions[p.profileId]
+            if (!entries || entries.length === 0) continue
+
+            const segments = buildSegments(entries)
+            if (segments.length === 0) continue
+
+            for (const e of entries) {
+                const t = Number(e.time)
+                if (t < raidStart) raidStart = t
+                if (t > raidEnd) raidEnd = t
+            }
+
+            const idx = raid.players.indexOf(p)
+            playerRows.push({
+                profileId: p.profileId,
+                name: intl(p.name, intl_dir),
+                player: p,
+                color: getPlayerColor(p, idx),
+                segments,
+                pmcIdx: pmcIndexMap[p.profileId],
+            })
+        }
+
+        // Sort: PMCs first, then by name
+        playerRows.sort((a, b) => {
+            const aIsPMC = a.player.team === 'Usec' || a.player.team === 'Bear'
+            const bIsPMC = b.player.team === 'Usec' || b.player.team === 'Bear'
+            if (aIsPMC !== bIsPMC) return aIsPMC ? -1 : 1
+            return a.name.localeCompare(b.name)
+        })
+
+        return { players: playerRows, raidStart, raidEnd }
+    }, [positions, raid, intl_dir, pmcIndexMap])
+
+    const { players: playerRows, raidStart, raidEnd } = data
+    const raidDuration = raidEnd - raidStart || 1
+
+    // Time axis ticks (every 60 seconds)
+    const ticks: number[] = []
+    for (let t = raidStart; t <= raidEnd; t += 60000) {
+        ticks.push(t)
+    }
+
+    if (playerRows.length === 0) {
+        return (
+            <div className="p-4 text-eft text-center opacity-50">
+                No behavior data available. Play a raid with the updated 1.0.0 mod to capture bot decisions.
+            </div>
+        )
+    }
+
+    const hasSain = !!raid?.detectedMods?.match(/SAIN/gi)
+
+    return (
+        <div className="p-4" style={{ overflowX: 'auto' }}>
+            {/* SAIN recommendation banner */}
+            {!hasSain && (
+                <div className="mb-3 px-3 py-2" style={{ background: 'rgba(245,158,11,0.12)', border: '1px solid rgba(245,158,11,0.3)', borderRadius: 4, fontSize: '12px', color: '#F59E0B' }}>
+                    <strong>SAIN recommended</strong> — Install <a href="https://hub.sp-tarkov.com/files/file/1062-sain-solarint-s-ai-modifications-full-ai-combat-system-replacement/" target="_blank" rel="noreferrer" style={{ color: '#F59E0B', textDecoration: 'underline' }}>SAIN</a> for detailed bot behavior data (Search, StandAndShoot, FirstAid, etc.). Without SAIN, behavior categories are approximate.
+                </div>
+            )}
+
+            {/* Legend */}
+            <div className="flex flex-wrap gap-4 mb-4">
+                {Object.values(BEHAVIOR_CATEGORIES).map(cat => (
+                    <div key={cat.key} className="flex items-center gap-1" style={{ fontSize: '11px' }}>
+                        <span style={{ width: 10, height: 10, borderRadius: 2, background: cat.color, display: 'inline-block' }}></span>
+                        <span className="text-eft">{cat.label}</span>
+                    </div>
+                ))}
+            </div>
+
+            {/* Time axis */}
+            <div className="flex" style={{ marginBottom: 2 }}>
+                <div style={{ width: 160, flexShrink: 0 }}></div>
+                <div className="relative flex-1" style={{ height: 16 }}>
+                    {ticks.map(t => {
+                        const left = ((t - raidStart) / raidDuration) * 100
+                        return (
+                            <span key={t} style={{
+                                position: 'absolute', left: `${left}%`, fontSize: '9px',
+                                color: '#9a8866', transform: 'translateX(-50%)', whiteSpace: 'nowrap'
+                            }}>
+                                {msToHMS(t)}
+                            </span>
+                        )
+                    })}
+                </div>
+            </div>
+
+            {/* Player rows */}
+            {playerRows.map(row => (
+                <div key={row.profileId} className="flex items-center" style={{ height: 26, marginBottom: 1 }}>
+                    {/* Player name with icon */}
+                    <div className="flex items-center" style={{ width: 160, flexShrink: 0, fontSize: '11px', overflow: 'hidden', whiteSpace: 'nowrap' }}>
+                        {getLegendIcon(row.player, row.color, row.pmcIdx)}
+                        <span className="text-eft" style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                            {row.name}
+                        </span>
+                    </div>
+                    {/* Segments bar */}
+                    <div className="relative flex-1" style={{ height: 20, background: 'rgba(154,136,102,0.08)', borderRadius: 2 }}>
+                        {row.segments.map((seg: BehaviorSegment, i: number) => {
+                            const left = ((seg.startTime - raidStart) / raidDuration) * 100
+                            const width = ((seg.endTime - seg.startTime) / raidDuration) * 100
+                            return (
+                                <div
+                                    key={i}
+                                    style={{
+                                        position: 'absolute',
+                                        left: `${left}%`,
+                                        width: `${Math.max(width, 0.2)}%`,
+                                        height: '100%',
+                                        background: seg.categoryColor,
+                                        opacity: 0.85,
+                                        borderRadius: 1,
+                                        cursor: 'pointer',
+                                    }}
+                                    onMouseEnter={(e) => setHoveredSegment({ seg, playerName: row.name, x: e.clientX, y: e.clientY })}
+                                    onMouseMove={(e) => setHoveredSegment(prev => prev ? { ...prev, x: e.clientX, y: e.clientY } : null)}
+                                    onMouseLeave={() => setHoveredSegment(null)}
+                                />
+                            )
+                        })}
+                    </div>
+                </div>
+            ))}
+
+            {/* Hover tooltip */}
+            {hoveredSegment && (
+                <div style={{
+                    position: 'fixed',
+                    left: hoveredSegment.x + 12,
+                    top: hoveredSegment.y - 10,
+                    background: '#1a1a1a',
+                    border: '1px solid #9a8866',
+                    padding: '6px 10px',
+                    fontSize: '11px',
+                    zIndex: 9999,
+                    pointerEvents: 'none',
+                    maxWidth: 300,
+                }}>
+                    <div style={{ color: hoveredSegment.seg.categoryColor, fontWeight: 'bold' }}>
+                        {hoveredSegment.seg.label}
+                    </div>
+                    <div style={{ color: '#ccc' }}>
+                        {formatDecisionLabel(hoveredSegment.seg.decision)}
+                    </div>
+                    <div style={{ color: '#999', fontSize: '10px' }}>
+                        {hoveredSegment.playerName} &middot; {msToHMS(hoveredSegment.seg.startTime)} - {msToHMS(hoveredSegment.seg.endTime)}
+                        {' '}({((hoveredSegment.seg.endTime - hoveredSegment.seg.startTime) / 1000).toFixed(1)}s)
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/Private/src/pages/V2/RaidCharts.css
+++ b/Private/src/pages/V2/RaidCharts.css
@@ -9,3 +9,25 @@
     grid-column-gap: 16px;
     grid-row-gap: 0px;
 }
+
+.difficulty-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    grid-gap: 12px;
+}
+
+/* Prevent SVG label text from being clipped */
+.pie-wrapper,
+.difficulty-grid > div {
+    overflow: visible;
+}
+
+.pie-wrapper .recharts-wrapper,
+.difficulty-grid .recharts-wrapper {
+    overflow: visible !important;
+}
+
+.pie-wrapper svg,
+.difficulty-grid svg {
+    overflow: visible;
+}

--- a/Private/src/pages/V2/RaidCharts.tsx
+++ b/Private/src/pages/V2/RaidCharts.tsx
@@ -1,16 +1,238 @@
-import { useEffect, useState } from 'react';
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie } from 'recharts';
+import { useEffect, useMemo, useState } from 'react';
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
 
 import './Raids.css'
 import './RaidCharts.css'
 import { useOutletContext } from 'react-router-dom';
 import { TrackingPlayerStatus, TrackingRaidData } from '../../types/api_types';
 import _ from 'lodash';
-import { msToHMS } from '../../helpers';
+import { intl, msToHMS } from '../../helpers';
+import { getLegendIcon, getPlayerColor, getPlayerFaction, buildPmcIndexMap } from '../../helpers/players';
 
-export default function RaidCharts() {        
-    const [ botsByTeam, setBotsByTeam ] = useState([] as any[]);
-    const [ botsByPersonality, setBotsByPersonality ] = useState([] as any[]);
+import cyr_to_en from '../../assets/cyr_to_en.json';
+
+const PIE_COLORS = [
+    '#9a8866', '#c4a96a', '#7a6b4e', '#bfa55a', '#d4c090',
+    '#5c5038', '#e0cc9a', '#8c7a56', '#a89260', '#6e6040',
+];
+
+const PERSONALITY_COLORS: Record<string, string> = {
+    'normal': '#3B82F6',
+    'timmy': '#22C55E',
+    'rat': '#A855F7',
+    'chad': '#EF4444',
+    'gigachad': '#FF0040',
+    'coward': '#FACC15',
+    'snappingturtle': '#14B8A6',
+    'player': '#06B6D4',
+};
+
+const PERSONALITY_FALLBACK = [
+    '#FF6B6B', '#06B6D4', '#14B8A6', '#F472B6', '#A78BFA',
+    '#34D399', '#FBBF24', '#FB923C', '#E879F9', '#2DD4BF',
+];
+
+const DIFFICULTY_COLORS: Record<string, string> = {
+    'easy': '#22C55E',
+    'normal': '#3B82F6',
+    'hard': '#F59E0B',
+    'impossible': '#EF4444',
+    'default': '#6B7280',
+};
+
+const FACTION_COLORS: Record<string, string> = {
+    'PMC': '#3357FF',
+    'Player Scav': '#33FF8D',
+    'Scav': '#33FF57',
+    'Sniper': '#00911a',
+    'Boss': '#FF0000',
+    'Goon': '#ff005d',
+    'Follower': '#ff7b00',
+    'Rogue': '#ff7b00',
+    'Raider': '#FF00FF',
+    'Cultist': '#6f00ff',
+    'Bloodhound': '#6d0000',
+    'Mercenary': '#FFD700',
+    'RUAF': '#4A90D9',
+    'UNTAR': '#00BFFF',
+    'Black Div': '#555555',
+    'Infected': '#7FFF00',
+    'Other': '#00eeff',
+    'Unknown': '#999',
+};
+
+function getFactionGroup(faction: string): string {
+    switch (faction) {
+        case 'PMC': return 'PMC';
+        case 'Player Scav':
+        case 'Scav':
+        case 'Sniper': return 'Scav';
+        case 'Boss': return 'Boss';
+        case 'Goon': return 'Goon';
+        case 'Follower':
+        case 'Rogue':
+        case 'Raider': return 'Raider/Rogue';
+        case 'Cultist': return 'Cultist';
+        case 'Bloodhound': return 'Bloodhound';
+        case 'Mercenary':
+        case 'RUAF':
+        case 'UNTAR':
+        case 'Black Div': return 'Factions';
+        case 'Infected': return 'Infected';
+        default: return 'Other';
+    }
+}
+
+type PlayerEntry = { name: string, playerObj: any, color: string, pmcIdx?: number };
+
+const TT: React.CSSProperties = { background: '#1a1a1a', border: '1px solid #9a8866', padding: '6px 10px', fontSize: '11px', maxWidth: '360px' };
+const TT_WIDE: React.CSSProperties = { ...TT, maxWidth: '400px', maxHeight: '350px', overflowY: 'auto' };
+
+function PlayerIcon({ player, color, pmcIdx }: { player: any, color: string, pmcIdx?: number }) {
+    if (!player) return null;
+    return getLegendIcon(player, color, pmcIdx);
+}
+
+function PlayerLine({ p }: { p: PlayerEntry }) {
+    return (
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: '1px', marginRight: '6px' }}>
+            <PlayerIcon player={p.playerObj} color={p.color} pmcIdx={p.pmcIdx} />
+            <span style={{ color: '#ccc' }}>{p.name}</span>
+        </span>
+    );
+}
+
+// Tooltip for Faction + Personality pies: show player names with icons
+function PiePlayersTooltip({ active, payload }: any) {
+    if (!active || !payload?.length) return null;
+    const d = payload[0]?.payload;
+    const players = d?.players as PlayerEntry[] | undefined;
+    return (
+        <div style={TT_WIDE}>
+            <div style={{ color: d?.color || '#9a8866', marginBottom: '4px', fontWeight: 'bold' }}>{d?.name} ({d?.value})</div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '2px 0' }}>
+                {players?.slice(0, 20).map((p, i) => <PlayerLine key={i} p={p} />)}
+            </div>
+            {players && players.length > 20 && <div style={{ color: '#666', marginTop: '2px' }}>+{players.length - 20} more</div>}
+        </div>
+    );
+}
+
+// Tooltip for Difficulty pie: group by faction group, show player names
+function DifficultyTooltip({ active, payload }: any) {
+    if (!active || !payload?.length) return null;
+    const d = payload[0]?.payload;
+    const groups = d?.groups as Record<string, PlayerEntry[]> | undefined;
+    return (
+        <div style={TT_WIDE}>
+            <div style={{ color: d?.color || '#9a8866', marginBottom: '4px', fontWeight: 'bold' }}>{d?.name} ({d?.value})</div>
+            {groups && Object.entries(groups).sort((a, b) => b[1].length - a[1].length).map(([group, players]) => (
+                <div key={group} style={{ marginBottom: '4px' }}>
+                    <div style={{ color: '#9a8866', fontWeight: 'bold', fontSize: '10px', marginBottom: '1px' }}>{group} ({players.length})</div>
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '2px 0', paddingLeft: '4px' }}>
+                        {players.slice(0, 12).map((p, i) => <PlayerLine key={i} p={p} />)}
+                        {players.length > 12 && <span style={{ color: '#666' }}>+{players.length - 12}</span>}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function ActiveBotsTooltip({ active, payload }: any) {
+    if (!active || !payload?.length) return null;
+    const d = payload[0]?.payload;
+    const factions = d?.factions as Record<string, number> | undefined;
+    return (
+        <div style={TT}>
+            <div style={{ color: '#9a8866', marginBottom: '4px', fontWeight: 'bold' }}>{d?.name} — {d?.uv} bots</div>
+            {factions && Object.keys(FACTION_COLORS).filter(f => factions[f]).map(faction => [faction, factions[faction]] as [string, number]).map(([faction, count]) => (
+                <div key={faction} style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                    <span style={{ width: '8px', height: '8px', borderRadius: '50%', background: FACTION_COLORS[faction] || '#999', flexShrink: 0 }}></span>
+                    <span style={{ color: FACTION_COLORS[faction] || '#ccc' }}>{faction}: <strong>{count}</strong></span>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function KillsTooltip({ active, payload }: any) {
+    if (!active || !payload?.length) return null;
+    const d = payload[0]?.payload;
+    const details = d?.details as any[] | undefined;
+    return (
+        <div style={TT}>
+            <div style={{ color: '#EF4444', marginBottom: '4px', fontWeight: 'bold' }}>{d?.name} — {d?.uv} kill{d?.uv > 1 ? 's' : ''}</div>
+            {details?.slice(0, 8).map((k: any, i: number) => (
+                <div key={i} style={{ color: '#ccc', display: 'flex', alignItems: 'center', gap: '2px', whiteSpace: 'nowrap', overflow: 'hidden' }}>
+                    <PlayerIcon player={k.killerPlayer} color={k.killerColor} pmcIdx={k.killerPmcIdx} />
+                    <span style={{ color: '#EF4444' }}>{k.killer}</span>
+                    <span style={{ opacity: 0.5, margin: '0 2px' }}>{' → '}</span>
+                    <PlayerIcon player={k.victimPlayer} color={k.victimColor} pmcIdx={k.victimPmcIdx} />
+                    <strong>{k.victim}</strong>
+                    <span style={{ opacity: 0.5, marginLeft: '4px' }}>({k.weapon}, {k.distance}m)</span>
+                </div>
+            ))}
+            {details && details.length > 8 && <div style={{ color: '#666' }}>+{details.length - 8} more</div>}
+        </div>
+    );
+}
+
+function LootingTooltip({ active, payload }: any) {
+    if (!active || !payload?.length) return null;
+    const d = payload[0]?.payload;
+    const details = d?.details as any[] | undefined;
+    return (
+        <div style={TT}>
+            <div style={{ color: '#22C55E', marginBottom: '4px', fontWeight: 'bold' }}>{d?.name} — {d?.uv} loot event{d?.uv > 1 ? 's' : ''}</div>
+            {details?.slice(0, 8).map((l: any, i: number) => (
+                <div key={i} style={{ color: '#ccc', display: 'flex', alignItems: 'center', gap: '2px', whiteSpace: 'nowrap', overflow: 'hidden' }}>
+                    <PlayerIcon player={l.playerObj} color={l.playerColor} pmcIdx={l.playerPmcIdx} />
+                    <span style={{ color: '#9a8866' }}>{l.player}</span>
+                    <span style={{ color: l.added ? '#22C55E' : '#F59E0B' }}>{l.added ? ' looted ' : ' dropped '}</span>
+                    <strong>{l.qty > 1 ? `${l.qty}x ` : ''}{l.item}</strong>
+                </div>
+            ))}
+            {details && details.length > 8 && <div style={{ color: '#666' }}>+{details.length - 8} more</div>}
+        </div>
+    );
+}
+
+function ShotsTooltip({ active, payload }: any) {
+    if (!active || !payload?.length) return null;
+    const d = payload[0]?.payload;
+    const shooters = d?.shooters as any[] | undefined;
+    return (
+        <div style={TT}>
+            <div style={{ color: '#8B5CF6', marginBottom: '4px', fontWeight: 'bold' }}>{d?.name} — {d?.uv} shot{d?.uv > 1 ? 's' : ''}</div>
+            {shooters?.slice(0, 6).map((s: any, i: number) => (
+                <div key={i} style={{ color: '#ccc', display: 'flex', alignItems: 'center', gap: '2px', whiteSpace: 'nowrap', overflow: 'hidden' }}>
+                    <PlayerIcon player={s.playerObj} color={s.playerColor} pmcIdx={s.playerPmcIdx} />
+                    <span style={{ color: '#9a8866' }}>{s.name}</span>:
+                    <strong style={{ marginLeft: '2px' }}>{s.count}</strong> shot{s.count > 1 ? 's' : ''}
+                    {s.weapon && <span style={{ opacity: 0.5, marginLeft: '4px' }}>({s.weapon})</span>}
+                </div>
+            ))}
+            {shooters && shooters.length > 6 && <div style={{ color: '#666' }}>+{shooters.length - 6} more</div>}
+        </div>
+    );
+}
+
+function PieLabel({ cx, cy, midAngle, outerRadius, name, value }: any) {
+    const RADIAN = Math.PI / 180;
+    const radius = outerRadius + 14;
+    const x = cx + radius * Math.cos(-midAngle * RADIAN);
+    const y = cy + radius * Math.sin(-midAngle * RADIAN);
+    return (
+        <text x={x} y={y} fill="#9a8866" textAnchor={x > cx ? 'start' : 'end'} dominantBaseline="central" fontSize={12}>
+            {name} ({value})
+        </text>
+    );
+}
+
+export default function RaidCharts() {
+    const [ botsByFaction, setBotsByFaction ] = useState([] as any[]);
+    const [ pmcPersonalities, setPmcPersonalities ] = useState([] as any[]);
     const [ botsByDifficulty, setBotsByDifficulty ] = useState([] as any[]);
 
     const [ activeBots, setActiveBots ] = useState([] as any[]);
@@ -18,50 +240,115 @@ export default function RaidCharts() {
     const [ lootings, setLootings ] = useState([] as any[]);
     const [ shots, setShots ] = useState([] as any[]);
 
-    const { raid } = useOutletContext() as {
-        raid: TrackingRaidData
+    const { raid, intl: intl_dir_ot } = useOutletContext() as {
+        raid: TrackingRaidData,
+        intl: { [key: string]: string }
     };
+
+    const intl_dir: Record<string, string> = useMemo(() => ({...intl_dir_ot, ...cyr_to_en}), [intl_dir_ot]);
 
     useEffect(() => {
         if (raid && raid.players) {
 
-            // Calculate Difficulty
-            const teams = {} as { [key:string] : number };
-            const difficulties = {} as { [key:string] : number };
-            const personalities = {} as { [key:string] : number };
-            for (let i = 0; i < raid.players.length; i++) {
-                const player = raid.players[i];
-
-                let brainKey = player.mod_SAIN_brain.toLowerCase();
-                personalities[brainKey] ? personalities[brainKey] = personalities[brainKey] + 1 : personalities[brainKey] = 1;
-
-                let difficultyKey = player.mod_SAIN_difficulty.toLowerCase();
-                difficulties[difficultyKey] ? difficulties[difficultyKey || 'default'] = difficulties[difficultyKey || 'default'] + 1 : difficulties[difficultyKey || 'default'] = 1;
-
-                let teamKey = player.team.toLowerCase();
-                teams[teamKey] ? teams[teamKey] = teams[teamKey] + 1 : teams[teamKey] = 1;
+            // Build lookup maps
+            const playerNameMap: Record<string, string> = {};
+            const playerFactionMap: Record<string, string> = {};
+            const playerObjMap: Record<string, any> = {};
+            const playerColorMap: Record<string, string> = {};
+            const pmcIndexMap = buildPmcIndexMap(raid.players);
+            for (let idx = 0; idx < raid.players.length; idx++) {
+                const p = raid.players[idx];
+                playerNameMap[p.profileId] = intl(p.name, intl_dir);
+                playerFactionMap[p.profileId] = getPlayerFaction(p);
+                playerObjMap[p.profileId] = p;
+                playerColorMap[p.profileId] = getPlayerColor(p, idx);
             }
-            
-            setBotsByTeam(_.map(teams, (team, key) => ({ name: key, value: team })))
-            setBotsByPersonality(_.map(personalities, (personality, key) => ({ name: key, value: personality })))
-            setBotsByDifficulty(_.map(difficulties, (difficulty, key) => ({ name: key, value: difficulty })))
 
-            // Calculate Active Bots
+            function makeEntry(p: any): PlayerEntry {
+                return {
+                    name: playerNameMap[p.profileId],
+                    playerObj: p,
+                    color: playerColorMap[p.profileId],
+                    pmcIdx: pmcIndexMap[p.profileId]
+                };
+            }
+
+            // Faction pie: { name, value, players[] }
+            const factionMap: Record<string, PlayerEntry[]> = {};
+            // Personality pie (PMC only): { name, value, players[] }
+            const brainMap: Record<string, PlayerEntry[]> = {};
+            // Difficulty pie: { name, value, groups: { factionGroup: PlayerEntry[] } }
+            const diffMap: Record<string, Record<string, PlayerEntry[]>> = {};
+
+            for (let i = 0; i < raid.players.length; i++) {
+                const player: any = raid.players[i];
+                const faction = getPlayerFaction(player);
+                const group = getFactionGroup(faction);
+                const entry = makeEntry(player);
+
+                // Faction
+                if (!factionMap[faction]) factionMap[faction] = [];
+                factionMap[faction].push(entry);
+
+                // Personality — PMC only
+                const isPMC = player.team === 'Usec' || player.team === 'Bear';
+                if (isPMC && player.mod_SAIN_brain) {
+                    const brainKey = player.mod_SAIN_brain.toLowerCase();
+                    if (brainKey !== 'player') {
+                        if (!brainMap[brainKey]) brainMap[brainKey] = [];
+                        brainMap[brainKey].push(entry);
+                    }
+                }
+
+                // Difficulty
+                if (player.mod_SAIN_difficulty) {
+                    const diffKey = player.mod_SAIN_difficulty.toLowerCase() || 'default';
+                    if (!diffMap[diffKey]) diffMap[diffKey] = {};
+                    if (!diffMap[diffKey][group]) diffMap[diffKey][group] = [];
+                    diffMap[diffKey][group].push(entry);
+                }
+            }
+
+            const factionData = Object.entries(factionMap)
+                .map(([name, players]) => ({ name, value: players.length, players, color: FACTION_COLORS[name] || '#999' }))
+                .sort((a, b) => b.value - a.value);
+            setBotsByFaction(factionData);
+
+            const personalityData = Object.entries(brainMap)
+                .map(([name, players], i) => ({ name, value: players.length, players, color: PERSONALITY_COLORS[name] || PERSONALITY_FALLBACK[i % PERSONALITY_FALLBACK.length] }))
+                .sort((a, b) => b.value - a.value);
+            setPmcPersonalities(personalityData);
+
+            const diffData = Object.entries(diffMap)
+                .map(([name, groups], i) => ({
+                    name,
+                    value: Object.values(groups).reduce((s, arr) => s + arr.length, 0),
+                    groups,
+                    color: DIFFICULTY_COLORS[name] || PIE_COLORS[i % PIE_COLORS.length]
+                }))
+                .sort((a, b) => b.value - a.value);
+            setBotsByDifficulty(diffData);
+
+            // Calculate Active Bots (with faction breakdown)
             let playersByTime = _.chain(raid.player_status).filter((ps: TrackingPlayerStatus) => ps.status === 'Alive').groupBy('time').valuesIn().value();
             const activeBotsChartData = [];
             for (let i = 0; i < playersByTime.length; i++) {
                 const playerStatuses = playersByTime[i];
                 const first = _.first(playerStatuses);
-
+                const factionBreakdown: Record<string, number> = {};
+                for (const ps of playerStatuses) {
+                    const faction = playerFactionMap[ps.profileId] || 'Unknown';
+                    factionBreakdown[faction] = (factionBreakdown[faction] || 0) + 1;
+                }
                 activeBotsChartData.push({
                     name: msToHMS(Number(first?.time)),
-                    uv: playerStatuses.length
+                    uv: playerStatuses.length,
+                    factions: factionBreakdown
                 })
             }
             setActiveBots(activeBotsChartData)
 
-
-            // Calculate Kills 
+            // Calculate Kills
             const killsGroup = [];
             let currentKillGroup = [] as any[];
             if (raid.kills) {
@@ -78,10 +365,7 @@ export default function RaidCharts() {
                         }
                     }
                 }
-                
-                if (currentKillGroup.length > 0) {
-                    killsGroup.push(currentKillGroup);
-                }
+                if (currentKillGroup.length > 0) killsGroup.push(currentKillGroup);
             }
 
             const killChartData_ = [];
@@ -90,14 +374,25 @@ export default function RaidCharts() {
                 if (group && group[0] && group[0].time) {
                     killChartData_.push({
                         name: msToHMS(Number(group[0].time)),
-                        uv: group.length
+                        uv: group.length,
+                        details: group.map((k: any) => ({
+                            killer: playerNameMap[k.profileId] || 'Unknown',
+                            killerPlayer: playerObjMap[k.profileId] || null,
+                            killerColor: playerColorMap[k.profileId] || '#999',
+                            killerPmcIdx: pmcIndexMap[k.profileId],
+                            victim: playerNameMap[k.killedId] || 'Unknown',
+                            victimPlayer: playerObjMap[k.killedId] || null,
+                            victimColor: playerColorMap[k.killedId] || '#999',
+                            victimPmcIdx: pmcIndexMap[k.killedId],
+                            weapon: intl(k.weapon.replace("Name", "ShortName"), intl_dir),
+                            distance: Number(k.distance).toFixed(1)
+                        }))
                     })
                 }
             }
             setKills(killChartData_)
 
-
-            // Calculate Lootings 
+            // Calculate Lootings
             const lootingsGroup = [];
             let currentLootingGroup = [] as any[];
             if (raid.looting) {
@@ -114,10 +409,7 @@ export default function RaidCharts() {
                         }
                     }
                 }
-                
-                if (currentLootingGroup.length > 0) {
-                    lootingsGroup.push(currentLootingGroup);
-                }
+                if (currentLootingGroup.length > 0) lootingsGroup.push(currentLootingGroup);
             }
 
             const lootingChartData_ = [];
@@ -126,14 +418,22 @@ export default function RaidCharts() {
                 if (group && group[0] && group[0].time) {
                     lootingChartData_.push({
                         name: msToHMS(Number(group[0].time)),
-                        uv: group.length
+                        uv: group.length,
+                        details: group.map((l: any) => ({
+                            player: playerNameMap[l.profileId] || 'Unknown',
+                            playerObj: playerObjMap[l.profileId] || null,
+                            playerColor: playerColorMap[l.profileId] || '#999',
+                            playerPmcIdx: pmcIndexMap[l.profileId],
+                            item: intl((l.itemName || l.name || '').replace("Short", ""), intl_dir),
+                            qty: Number(l.qty) || 1,
+                            added: !!String(l.added).match(/^(1|true)$/i)
+                        }))
                     })
                 }
             }
             setLootings(lootingChartData_)
 
-
-            // Calculate Shots 
+            // Calculate Shots
             const shotsGroup = [];
             let currentShotGroup = [] as any[];
             if (raid.ballistic) {
@@ -150,114 +450,127 @@ export default function RaidCharts() {
                         }
                     }
                 }
-                
-                if (currentShotGroup.length > 0) {
-                    shotsGroup.push(currentShotGroup);
-                }
+                if (currentShotGroup.length > 0) shotsGroup.push(currentShotGroup);
             }
 
             const shotChartData_ = [];
             for (let i = 0; i < shotsGroup.length; i++) {
                 const group = shotsGroup[i];
                 if (group && group[0] && group[0].time) {
+                    const byShooter: Record<string, { count: number, weapons: Set<string>, profileId: string }> = {};
+                    for (const s of group) {
+                        const pid = s.profileId;
+                        const name = playerNameMap[pid] || 'Unknown';
+                        if (!byShooter[name]) byShooter[name] = { count: 0, weapons: new Set(), profileId: pid };
+                        byShooter[name].count++;
+                        if (s.weaponName) byShooter[name].weapons.add(s.weaponName);
+                    }
                     shotChartData_.push({
                         name: msToHMS(Number(group[0].time)),
-                        uv: group.length
+                        uv: group.length,
+                        shooters: Object.entries(byShooter)
+                            .sort((a, b) => b[1].count - a[1].count)
+                            .map(([name, data]) => ({
+                                name,
+                                count: data.count,
+                                weapon: [...data.weapons].join(', ') || null,
+                                playerObj: playerObjMap[data.profileId] || null,
+                                playerColor: playerColorMap[data.profileId] || '#999',
+                                playerPmcIdx: pmcIndexMap[data.profileId]
+                            }))
                     })
                 }
             }
             setShots(shotChartData_)
 
-
-
         }
 
-    }, [raid])
+    }, [raid, intl_dir])
 
-    const CustomTooltip = () => {
-        return null;
-    };
-    
     return (
         <section className="chart-container">
 
             { raid.detectedMods?.match(/SAIN/gi) ?
             <div className="gauges my-4">
                 <div>
-                    <div className='text-center w-full text-lg font-bold bg-eft text-black'>Bots By Team</div>
-                    <div className="border border-eft">
-                        <PieChart width={290} height={200}>
-                            <Pie
-                                dataKey="value"
-                                isAnimationActive={false}
-                                data={botsByTeam}
-                                cx="50%"
-                                cy="50%"
-                                outerRadius={80}
-                                fill="#9a8866"
-                                stroke='black'
-                                strokeWidth={2}
-                                />
-                            <Tooltip />
-                        </PieChart>
+                    <div className='text-center w-full text-lg font-bold bg-eft text-black'>Bots By Faction</div>
+                    <div className="border border-eft pie-wrapper">
+                        <ResponsiveContainer width="100%" height={240}>
+                            <PieChart>
+                                <Pie
+                                    dataKey="value"
+                                    isAnimationActive={false}
+                                    data={botsByFaction}
+                                    cx="50%"
+                                    cy="50%"
+                                    outerRadius={60}
+                                    stroke='black'
+                                    strokeWidth={2}
+                                    label={PieLabel}
+                                >
+                                    {botsByFaction.map((d, i) => <Cell key={i} fill={FACTION_COLORS[d.name] || PIE_COLORS[i % PIE_COLORS.length]} />)}
+                                </Pie>
+                                <Tooltip content={<PiePlayersTooltip />} />
+                            </PieChart>
+                        </ResponsiveContainer>
                     </div>
                 </div>
                 <div>
-                    <div className='text-center w-full text-lg font-bold bg-eft text-black'>Bots By Personalities</div>
-                    <div className="border border-eft">
-                        <PieChart width={290} height={200}>
-                            <Pie
-                                dataKey="value"
-                                isAnimationActive={false}
-                                data={botsByPersonality}
-                                cx="50%"
-                                cy="50%"
-                                outerRadius={80}
-                                fill="#9a8866"
-                                stroke='black'
-                                strokeWidth={2}
-                                />
-                            <Tooltip />
-                        </PieChart>
+                    <div className='text-center w-full text-lg font-bold bg-eft text-black'>PMC Personalities</div>
+                    <div className="border border-eft pie-wrapper">
+                        <ResponsiveContainer width="100%" height={240}>
+                            <PieChart>
+                                <Pie
+                                    dataKey="value"
+                                    isAnimationActive={false}
+                                    data={pmcPersonalities}
+                                    cx="50%"
+                                    cy="50%"
+                                    outerRadius={60}
+                                    stroke='black'
+                                    strokeWidth={2}
+                                    label={PieLabel}
+                                >
+                                    {pmcPersonalities.map((d, i) => <Cell key={i} fill={PERSONALITY_COLORS[d.name] || PERSONALITY_FALLBACK[i % PERSONALITY_FALLBACK.length]} />)}
+                                </Pie>
+                                <Tooltip content={<PiePlayersTooltip />} />
+                            </PieChart>
+                        </ResponsiveContainer>
                     </div>
                 </div>
                 <div>
                     <div className='text-center w-full text-lg font-bold bg-eft text-black'>Bots By Difficulty</div>
-                    <div className="border border-eft">
-                        <PieChart width={290} height={200}>
-                            <Pie
-                                dataKey="value"
-                                isAnimationActive={false}
-                                data={botsByDifficulty}
-                                cx="50%"
-                                cy="50%"
-                                outerRadius={80}
-                                fill="#9a8866"
-                                stroke='black'
-                                strokeWidth={2}
-                                />
-                            <Tooltip />
-                        </PieChart>
+                    <div className="border border-eft pie-wrapper">
+                        <ResponsiveContainer width="100%" height={240}>
+                            <PieChart>
+                                <Pie
+                                    dataKey="value"
+                                    isAnimationActive={false}
+                                    data={botsByDifficulty}
+                                    cx="50%"
+                                    cy="50%"
+                                    outerRadius={60}
+                                    stroke='black'
+                                    strokeWidth={2}
+                                    label={PieLabel}
+                                >
+                                    {botsByDifficulty.map((d, i) => <Cell key={i} fill={DIFFICULTY_COLORS[d.name] || PIE_COLORS[i % PIE_COLORS.length]} />)}
+                                </Pie>
+                                <Tooltip content={<DifficultyTooltip />} />
+                            </PieChart>
+                        </ResponsiveContainer>
                     </div>
                 </div>
-
-
             </div>
             : null }
 
             <div className='text-center w-full text-lg font-bold bg-eft text-black'>Active Bots By Time</div>
             <div className="chart mb-4 border border-eft">
                 <ResponsiveContainer>
-                    <AreaChart
-                        data={activeBots}
-                        margin={{
-                            top: 10,
-                            right: 30
-                        }}
-                    >
-                    <Tooltip content={<CustomTooltip />} />
+                    <AreaChart data={activeBots} margin={{ top: 10, right: 30 }}>
+                    <Tooltip content={<ActiveBotsTooltip />} />
                     <XAxis dataKey="name" angle={-30} dy={20} dx={-30} />
-                    <YAxis tickCount={5}  />
+                    <YAxis tickCount={5} />
                     <CartesianGrid strokeDasharray="1 1" stroke='#9a8866' />
                     <Area type="monotone" dataKey="uv" stroke="#9a8866" fill="#9a8866" />
                     </AreaChart>
@@ -265,56 +578,40 @@ export default function RaidCharts() {
             </div>
 
             <div className='text-center w-full text-lg font-bold bg-eft text-black'>Kill Activity By Time</div>
-            <div className="chart mb-4 px-4 border border-eft">
+            <div className="chart mb-4 border border-eft">
                 <ResponsiveContainer>
-                    <AreaChart
-                        data={kills}
-                        margin={{
-                            top: 10,
-                            right: 30
-                        }}
-                    >
-                    <Tooltip content={<CustomTooltip />} />
-                    <YAxis tickCount={5}  />
+                    <AreaChart data={kills} margin={{ top: 10, right: 30 }}>
+                    <Tooltip content={<KillsTooltip />} />
+                    <XAxis dataKey="name" angle={-30} dy={20} dx={-30} />
+                    <YAxis tickCount={5} />
                     <CartesianGrid strokeDasharray="1 1" stroke='#9a8866' />
-                    <Area type="monotone" dataKey="uv" stroke="#9a8866" fill="#9a8866" />
+                    <Area type="monotone" dataKey="uv" stroke="#EF4444" fill="rgba(239,68,68,0.3)" />
                     </AreaChart>
                 </ResponsiveContainer>
             </div>
 
             <div className='text-center w-full text-lg font-bold bg-eft text-black'>Looting Activity By Time</div>
-            <div className="chart mb-4 px-4 border border-eft">
+            <div className="chart mb-4 border border-eft">
                 <ResponsiveContainer>
-                    <AreaChart
-                        data={lootings}
-                        margin={{
-                            top: 10,
-                            right: 30
-                        }}
-                    >
-                    <Tooltip content={<CustomTooltip />} />
-                    {/* <XAxis dataKey="name" angle={-90} dy={40} dx={-6} /> */}
-                    <YAxis tickCount={5}  />
+                    <AreaChart data={lootings} margin={{ top: 10, right: 30 }}>
+                    <Tooltip content={<LootingTooltip />} />
+                    <XAxis dataKey="name" angle={-30} dy={20} dx={-30} />
+                    <YAxis tickCount={5} />
                     <CartesianGrid strokeDasharray="1 1" stroke='#9a8866' />
-                    <Area type="monotone" dataKey="uv" stroke="#9a8866" fill="#9a8866" />
+                    <Area type="monotone" dataKey="uv" stroke="#22C55E" fill="rgba(34,197,94,0.3)" />
                     </AreaChart>
                 </ResponsiveContainer>
             </div>
 
             <div className='text-center w-full text-lg font-bold bg-eft text-black'>Projectile Activity By Time</div>
-            <div className="chart mb-4 px-4 border border-eft">
+            <div className="chart mb-4 border border-eft">
                 <ResponsiveContainer>
-                    <AreaChart
-                        data={shots}
-                        margin={{
-                            top: 10,
-                            right: 30
-                        }}
-                    >
-                    <Tooltip content={<CustomTooltip />} />
-                    <YAxis tickCount={10}  />
+                    <AreaChart data={shots} margin={{ top: 10, right: 30 }}>
+                    <Tooltip content={<ShotsTooltip />} />
+                    <XAxis dataKey="name" angle={-30} dy={20} dx={-30} />
+                    <YAxis tickCount={10} />
                     <CartesianGrid strokeDasharray="1 1" stroke='#9a8866' />
-                    <Area type="monotone" dataKey="uv" stroke="#9a8866" fill="#9a8866" />
+                    <Area type="monotone" dataKey="uv" stroke="#8B5CF6" fill="rgba(139,92,246,0.3)" />
                     </AreaChart>
                 </ResponsiveContainer>
             </div>

--- a/Private/src/pages/V2/RaidOverview.tsx
+++ b/Private/src/pages/V2/RaidOverview.tsx
@@ -60,6 +60,8 @@ export default function RaidOverview() {
     const [ groupedBy, setGroupedBy ] = useState([] as TrackingRaidDataPlayers[][]);
     const [ sortKey, setSortKey ] = useState<SortKey>(null);
     const [ sortDir, setSortDir ] = useState<SortDir>('desc');
+    const [ killedByMap, setKilledByMap ] = useState<Map<string, { killerName: string, weapon: string, distance: string, bodyPart: string }>>(new Map());
+    const [ selectedProfileId, setSelectedProfileId ] = useState<string | null>(null);
 
     const intl_dir : Record<string, string> = {...intl_dir_ot, ...cyr_to_en};
 
@@ -121,6 +123,23 @@ export default function RaidOverview() {
           })
         }
         setCalcStats(calculatedStats);
+
+        const nameMap = new Map<string, string>();
+        for (const p of raid.players) {
+          nameMap.set(p.profileId, p.name);
+        }
+        const newKilledByMap = new Map<string, { killerName: string, weapon: string, distance: string, bodyPart: string }>();
+        if (raid.kills) {
+          for (const kill of raid.kills) {
+            newKilledByMap.set(kill.killedId, {
+              killerName: nameMap.get(kill.profileId) || 'Unknown',
+              weapon: kill.weapon,
+              distance: kill.distance,
+              bodyPart: kill.bodyPart,
+            });
+          }
+        }
+        setKilledByMap(newKilledByMap);
 
         if (groupedByType === '') {
           setGroupedBy([[...raid.players]])
@@ -292,6 +311,13 @@ export default function RaidOverview() {
       function generatePlayerTable(raid: TrackingRaidData) {
         if (!raid || !groupedBy || groupedBy.length === 0) return null;
 
+        const victimIds = selectedProfileId
+          ? new Set(raid.kills?.filter(k => k.profileId === selectedProfileId).map(k => k.killedId))
+          : new Set<string>();
+        const killerOfSelected = selectedProfileId
+          ? raid.kills?.find(k => k.killedId === selectedProfileId)?.profileId
+          : null;
+
         return groupedBy.map((gp, groupIndex) => {
           const sorted = sortPlayers(gp);
           return sorted.map((p, index) => {
@@ -302,14 +328,23 @@ export default function RaidOverview() {
             const stats = calcStats?.get(p.profileId);
             const accuracy = stats?.accuracy || 0;
             const accuracyColor = accuracy >= 50 ? '#22C55E' : accuracy >= 20 ? '#EAB308' : '#EF4444';
+            const killInfo = isDead ? killedByMap.get(p.profileId) : null;
 
             const groupBorder = index === 0 ? 'border-t border-dashed border-eft' : index === sorted.length - 1 ? 'border-b border-dashed border-eft' : '';
             const groupTint = groupIndex % 2 === 1 ? 'leaderboard-group-alt' : '';
 
+            let highlightClass = '';
+            if (selectedProfileId) {
+              if (p.profileId === selectedProfileId) highlightClass = 'leaderboard-selected';
+              else if (victimIds.has(p.profileId)) highlightClass = 'leaderboard-victim';
+              else if (p.profileId === killerOfSelected) highlightClass = 'leaderboard-killer';
+            }
+
             return (
               <tr
                 key={`g${groupIndex}-${index}`}
-                className={`${isDead ? 'opacity-75' : ''} ${groupBorder} ${groupTint} ${isMainPlayer ? 'leaderboard-player-row font-bold' : ''}`}
+                className={`${isDead ? 'opacity-75' : ''} ${groupBorder} ${groupTint} ${isMainPlayer ? 'leaderboard-player-row font-bold' : ''} ${highlightClass}`}
+                onClick={() => setSelectedProfileId(prev => prev === p.profileId ? null : p.profileId)}
               >
                 <td className="text-center p-2">
                   <span
@@ -321,7 +356,14 @@ export default function RaidOverview() {
                 </td>
                 <td className="text-center p-2 uppercase border-x border-eft">{p.group}</td>
                 <td className="text-center p-2 border-x border-eft">{p.level}</td>
-                <td className="text-left p-2">{intl(BOSS_NAME_OVERRIDES[p.name] || p.name, intl_dir)}</td>
+                <td className="text-left p-2">
+                  <div>{intl(BOSS_NAME_OVERRIDES[p.name] || p.name, intl_dir)}</div>
+                  {killInfo && (
+                    <div className="text-xs opacity-50 mt-0.5">
+                      by {intl(BOSS_NAME_OVERRIDES[killInfo.killerName] || killInfo.killerName, intl_dir)} ({killInfo.weapon}, {Number(killInfo.distance).toFixed(0)}m, {killInfo.bodyPart})
+                    </div>
+                  )}
+                </td>
                 <td className="text-center p-2 border-x border-eft">
                   {isDead
                     ? <span className="text-red-500 font-semibold">KIA</span>
@@ -369,7 +411,7 @@ export default function RaidOverview() {
         <section className="mt-4">
             <div className="w-full flex flex-row justify-between items-center">
               <span className="text-lg font-bold">Leaderboard</span>
-              <span className="text-sm opacity-70">Group by Side, Team, or Spawned | Click Lvl, K, L, A% to sort</span>
+              <span className="text-sm opacity-70">Click row to show kills | Sort by Lvl, K, L, A%</span>
             </div>
             <table id="raid-leaderboard" className="mb-2 w-full border border-eft">
                 <thead>

--- a/Private/src/pages/V2/RaidOverview.tsx
+++ b/Private/src/pages/V2/RaidOverview.tsx
@@ -16,23 +16,90 @@ const BOSS_NAME_OVERRIDES: Record<string, string> = {
     'Партизан': 'Partizan',
 }
 
+const FACTION_COLORS: Record<string, { color: string, label: string }> = {
+    'BOSS':        { color: '#FF0000', label: 'Boss' },
+    'GOON':        { color: '#ff005d', label: 'Goon' },
+    'FOLLOWER':    { color: '#ff7b00', label: 'Follower' },
+    'RAIDER':      { color: '#FF00FF', label: 'Raider' },
+    'ROGUE':       { color: '#ff7b00', label: 'Rogue' },
+    'CULTIST':     { color: '#6f00ff', label: 'Cultist' },
+    'BLOODHOUND':  { color: '#6d0000', label: 'Bloodhound' },
+    'MERCENARY':   { color: '#FFD700', label: 'Mercenary' },
+    'RUAF':        { color: '#4A90D9', label: 'RUAF' },
+    'UNTAR':       { color: '#00BFFF', label: 'UNTAR' },
+    'BLACK DIV':   { color: '#555555', label: 'Black Div' },
+    'SNIPER':      { color: '#00911a', label: 'Sniper' },
+    'PLAYER SCAV': { color: '#33FF8D', label: 'P. Scav' },
+    'INFECTED':    { color: '#7FFF00', label: 'Infected' },
+    'SPECIAL':     { color: '#00eeff', label: 'Special' },
+};
+
+const SIDE_COLORS: Record<string, { color: string, label: string }> = {
+    'USEC':   { color: '#1E90FF', label: 'USEC' },
+    'Bear':   { color: '#CD5C5C', label: 'BEAR' },
+    'Savage': { color: '#33FF57', label: 'Scav' },
+};
+
+function needsDarkText(hex: string): boolean {
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.5;
+}
+
+type SortKey = 'lvl' | 'kills' | 'lootings' | 'accuracy' | null;
+type SortDir = 'asc' | 'desc';
+
 export default function RaidOverview() {
     const { raid, intl: intl_dir_ot } = useOutletContext() as { raid: TrackingRaidData, intl: { [key:string] : string } };
 
-    
+
     const [ calcStats, setCalcStats ] = useState(null as null | Map<string, { kills: number, lootings: number, accuracy: number }>);
     const [ raidSummary, setRaidSummary ] = useState([] as { title: string; value: any;}[]);
     const [ groupedByType, setGroupedByType ] = useState('' as string);
     const [ groupedBy, setGroupedBy ] = useState([] as TrackingRaidDataPlayers[][]);
-    
+    const [ sortKey, setSortKey ] = useState<SortKey>(null);
+    const [ sortDir, setSortDir ] = useState<SortDir>('desc');
+
     const intl_dir : Record<string, string> = {...intl_dir_ot, ...cyr_to_en};
+
+    function handleSort(key: SortKey) {
+      if (sortKey === key) {
+        setSortDir(prev => prev === 'asc' ? 'desc' : 'asc');
+      } else {
+        setSortKey(key);
+        setSortDir('desc');
+      }
+    }
+
+    function sortIndicator(key: SortKey) {
+      if (sortKey !== key) return '';
+      return sortDir === 'asc' ? ' ▲' : ' ▼';
+    }
+
+    function sortPlayers(players: TrackingRaidDataPlayers[]): TrackingRaidDataPlayers[] {
+      if (!sortKey || !calcStats) return players;
+      return [...players].sort((a, b) => {
+        let aVal = 0, bVal = 0;
+        if (sortKey === 'lvl') {
+          aVal = Number(a.level) || 0;
+          bVal = Number(b.level) || 0;
+        } else {
+          const aStats = calcStats.get(a.profileId);
+          const bStats = calcStats.get(b.profileId);
+          aVal = aStats ? aStats[sortKey] : 0;
+          bVal = bStats ? bStats[sortKey] : 0;
+        }
+        return sortDir === 'asc' ? aVal - bVal : bVal - aVal;
+      });
+    }
 
     useEffect(() => {
       if (raid && raid.players) {
         const calculatedStats = new Map();
         for (let i = 0; i < raid.players.length; i++) {
           const player = raid.players[i];
-          
+
           let kills = _.filter(raid.kills, (killer) => killer.profileId === player.profileId).length;
           let lootingsAdded = _.filter(raid.looting, (looter) => looter.profileId === player.profileId && looter.added === '1').length;
           let lootingsRemoved = _.filter(raid.looting, (looter) => looter.profileId === player.profileId && looter.added === '0').length;
@@ -83,33 +150,33 @@ export default function RaidOverview() {
         title: 'Status',
         value: raid.exitStatus
       });
-  
+
       newRaidSummary.push({
         title: 'Time In Raid',
         value: msToHMS(Number(raid.timeInRaid))
       });
-      
-  
+
+
       newRaidSummary.push({
         title: 'Extract Point',
         value: raid.exitName || '-'
       });
-      
+
       newRaidSummary.push({
         title: 'Total Players/Bots',
         value: raid.players ? raid.players.length : 0
       });
-      
+
       newRaidSummary.push({
         title: 'Peak Active Bots',
         value: raid.player_status ? _.maxBy(_.chain(raid.player_status).filter(p => p.status === 'Alive').groupBy('time').values().value(), 'length')?.length : '?'
       });
-      
+
       newRaidSummary.push({
         title: 'Total Kills',
         value: raid.kills ? raid.kills.length : 0
       });
-      
+
       newRaidSummary.push({
         title: 'Detected Mods',
         // @ts-ignore
@@ -119,11 +186,11 @@ export default function RaidOverview() {
       let positionsTrackedMap = { "COMPILED" : "Available", "RAW" : "Processing", "NOT_AVAILABLE" : "Not Available" }
       newRaidSummary.push({
         title: 'Positional Data',
-  
+
         // @ts-ignore
         value: raid.positionsTracked ? positionsTrackedMap[raid.positionsTracked] : 'N/A'
       });
-  
+
       setRaidSummary(newRaidSummary);
     },[ raid, groupedByType ])
 
@@ -142,7 +209,7 @@ export default function RaidOverview() {
                   type: 'UNKNOWN'
               };
           }
-        
+
           switch (botMapping.type){
               case 'BOSS':
                   return "BOSS"
@@ -170,69 +237,115 @@ export default function RaidOverview() {
                   return "UNTAR"
               case 'BLACKDIV':
                   return "BLACK DIV"
+              case 'INFECTED':
+                  return "INFECTED"
+              case 'SPECIAL':
+              case 'OTHER':
+                  return "SPECIAL"
               default:
                   if(player.team === "Savage") {
                     return ""
-                  } 
+                  }
                   return player.mod_SAIN_brain != null ? `${player.mod_SAIN_brain}` : "(PMC)"
           }
         }
-    
+
         return "(UNKNOWN)"
       }
-    
-      function getPlayerDifficultyAndBrain(player: TrackingRaidDataPlayers): string {    
+
+      function getPlayerDifficultyAndBrain(player: TrackingRaidDataPlayers): string {
         if (player) {
           let difficulty = player.mod_SAIN_difficulty;
           let brain = getPlayerBrain(player);
-    
+
           if (difficulty !== null && difficulty !== "") {
             if(player.team === "Savage" && brain === "") {
               return difficulty;
             }
             return `${difficulty} - ${brain}`;
           }
-    
+
           else if (player.team === "Savage") {
             if(brain !== null && brain !== "") {
               return `${brain}`;
             }
             else return "";
           }
-    
+
           return `${brain}`;
         }
-    
+
         return "";
       }
 
-      function generatePlayerTable(raid: TrackingRaidData ) {
-        
-        return (raid && groupedBy && groupedBy.length > 0 ? groupedBy.map( (gp) => gp.map( (p, index) => {
-          const SAIN = getPlayerDifficultyAndBrain(p).toLowerCase();
-          const LAST_STATUS = _.chain(raid.player_status).filter((ps) => ps.profileId === p.profileId && ps.status === 'Dead').sortBy('time', 'desc').first().value();
-          
-          let KIA = true;
-          if (LAST_STATUS) {
-            KIA = false;
-          }
+      function getFactionBadge(player: TrackingRaidDataPlayers, isMainPlayer: boolean): { color: string, label: string } {
+        if (isMainPlayer) {
+          return { color: '#9a8866', label: 'Player' };
+        }
+        const brain = getPlayerBrain(player);
+        if (FACTION_COLORS[brain]) {
+          return FACTION_COLORS[brain];
+        }
+        return SIDE_COLORS[player.team] || { color: '#6B7280', label: player.team };
+      }
 
-          return (<tr key={`group-${index}`} className={`${KIA ? '' : ' text-red-700 opacity-85'} ${index === 0 || (index === gp.length - 1) ? (index === 0 ? 'border-t border-dashed border-eft' : 'border-b border-dashed border-eft' ) : '' } ${SAIN === 'player' ? 'font-bold' : ''}`}>
-              <td className="text-right p-2 uppercase">{ p.team === 'Savage' ? 'Scav' : p.team }</td>
-              <td className="text-center p-2 uppercase border-x border-eft">{ p.group }</td>
-              <td className="text-center p-2 uppercase border-x border-eft">{ p.level }</td>
-              <td className="text-left p-2">{KIA ? '' : ' 💀 '}{ intl(BOSS_NAME_OVERRIDES[p.name] || p.name, intl_dir) }</td>
-              <td className="text-right p-2 capitalize">{ raid.detectedMods?.match(/SAIN/gi) ? SAIN : '' }</td>
-              <td className="text-center p-2 w-12 border-l border-eft">{ calcStats ? calcStats.get(p.profileId)?.kills || '-' : null  }</td>
-              <td className={`text-center p-2 w-12 ${(calcStats && (calcStats.get(p.profileId)?.lootings || 0) < 0) ? 'text-red-400' : 'text-green-400'}`}>{ calcStats ? calcStats.get(p.profileId)?.lootings || '-'  : null }</td>
-              <td className="text-center p-2 w-12">
-                { calcStats ? calcStats.get(p.profileId)?.accuracy || '-'  : null }
-                {calcStats && calcStats.get(p.profileId)?.accuracy ? '%' : ''}
-              </td>
-              <td className="text-right p-2 border-l border-eft">{ msToHMS(Number(p.spawnTime)) }</td>
-          </tr>)})
-      )
-      : '')
+      function generatePlayerTable(raid: TrackingRaidData) {
+        if (!raid || !groupedBy || groupedBy.length === 0) return null;
+
+        return groupedBy.map((gp, groupIndex) => {
+          const sorted = sortPlayers(gp);
+          return sorted.map((p, index) => {
+            const SAIN = getPlayerDifficultyAndBrain(p).toLowerCase();
+            const isDead = _.chain(raid.player_status).filter((ps) => ps.profileId === p.profileId && ps.status === 'Dead').sortBy('time', 'desc').first().value();
+            const isMainPlayer = p.profileId === raid.profileId;
+            const badge = getFactionBadge(p, isMainPlayer);
+            const stats = calcStats?.get(p.profileId);
+            const accuracy = stats?.accuracy || 0;
+            const accuracyColor = accuracy >= 50 ? '#22C55E' : accuracy >= 20 ? '#EAB308' : '#EF4444';
+
+            const groupBorder = index === 0 ? 'border-t border-dashed border-eft' : index === sorted.length - 1 ? 'border-b border-dashed border-eft' : '';
+            const groupTint = groupIndex % 2 === 1 ? 'leaderboard-group-alt' : '';
+
+            return (
+              <tr
+                key={`g${groupIndex}-${index}`}
+                className={`${isDead ? 'opacity-75' : ''} ${groupBorder} ${groupTint} ${isMainPlayer ? 'leaderboard-player-row font-bold' : ''}`}
+              >
+                <td className="text-center p-2">
+                  <span
+                    className="inline-block rounded px-2 py-0.5 text-xs font-bold uppercase whitespace-nowrap"
+                    style={{ background: badge.color, color: needsDarkText(badge.color) ? '#000' : '#fff' }}
+                  >
+                    {badge.label}
+                  </span>
+                </td>
+                <td className="text-center p-2 uppercase border-x border-eft">{p.group}</td>
+                <td className="text-center p-2 border-x border-eft">{p.level}</td>
+                <td className="text-left p-2">{intl(BOSS_NAME_OVERRIDES[p.name] || p.name, intl_dir)}</td>
+                <td className="text-center p-2 border-x border-eft">
+                  {isDead
+                    ? <span className="text-red-500 font-semibold">KIA</span>
+                    : <span className="text-green-500 font-semibold">Alive</span>
+                  }
+                </td>
+                <td className="text-right p-2 capitalize">{raid.detectedMods?.match(/SAIN/gi) ? SAIN : ''}</td>
+                <td className="text-center p-2 w-12 border-l border-eft">{stats ? stats.kills || '-' : null}</td>
+                <td className={`text-center p-2 w-12 ${(stats && stats.lootings < 0) ? 'text-red-400' : 'text-green-400'}`}>{stats ? stats.lootings || '-' : null}</td>
+                <td className="text-center p-2 w-24">
+                  {stats ? (
+                    <div className="flex items-center justify-center gap-1">
+                      <div className="w-10 h-1.5 rounded-full overflow-hidden" style={{ background: '#333' }}>
+                        <div className="h-full rounded-full" style={{ width: `${accuracy}%`, background: accuracyColor }} />
+                      </div>
+                      <span className="text-xs">{accuracy > 0 ? `${accuracy}%` : '-'}</span>
+                    </div>
+                  ) : null}
+                </td>
+                <td className="text-right p-2 border-l border-eft">{msToHMS(Number(p.spawnTime))}</td>
+              </tr>
+            );
+          });
+        });
       }
 
     return (
@@ -241,7 +354,7 @@ export default function RaidOverview() {
           <div className="w-full text-lg font-bold">Overview</div>
           <table id="raid-overview" className="mb-2 w-full border border-eft">
                   <tbody>
-                      {raidSummary && raidSummary.length ? raidSummary.map(rs => 
+                      {raidSummary && raidSummary.length ? raidSummary.map(rs =>
                         <tr key={rs.value}>
                           <td className="text-right bg-eft text-black font-bold px-2">{ rs.title }</td>
                           <td className="px-2">{ rs.value }</td>
@@ -254,26 +367,27 @@ export default function RaidOverview() {
         </section>
 
         <section className="mt-4">
-            <div className="w-full flex flex-row justify-between">
+            <div className="w-full flex flex-row justify-between items-center">
               <span className="text-lg font-bold">Leaderboard</span>
-              <span>Sort by Side, Team or Spawned</span>
+              <span className="text-sm opacity-70">Group by Side, Team, or Spawned | Click Lvl, K, L, A% to sort</span>
             </div>
             <table id="raid-leaderboard" className="mb-2 w-full border border-eft">
                 <thead>
                     <tr className="bg-eft text-black">
-                        <th className={`text-right px-2 underline cursor-pointer ${groupedByType === 'TEAM' ? 'bg-black text-eft' : ''}`} onClick={() => setGroupedByType('TEAM')}>Side</th>
-                        <th className={`text-right px-2 underline cursor-pointer ${groupedByType === 'GROUP' ? 'bg-black text-eft' : ''}`} onClick={() => setGroupedByType('GROUP')}>Team</th>
-                        <th className="text-right px-2">Lvl</th>
+                        <th className={`text-center px-2 underline cursor-pointer ${groupedByType === 'TEAM' ? 'bg-black text-eft' : ''}`} onClick={() => setGroupedByType('TEAM')}>Side</th>
+                        <th className={`text-center px-2 underline cursor-pointer ${groupedByType === 'GROUP' ? 'bg-black text-eft' : ''}`} onClick={() => setGroupedByType('GROUP')}>Team</th>
+                        <th className="text-center px-2 cursor-pointer hover:bg-black/10" onClick={() => handleSort('lvl')}>Lvl{sortIndicator('lvl')}</th>
                         <th className="text-left px-2">Username</th>
-                        <th className="text-right px-2"> { raid.detectedMods?.match(/SAIN/gi) ? 'SAIN' : '' }</th>
-                        <th className="text-center px-2" title="Kills">K</th>
-                        <th className="text-center px-2" title="Looted items">L</th>
-                        <th className="text-center px-2" title="Accuracy">A%</th>
+                        <th className="text-center px-2">Status</th>
+                        <th className="text-right px-2">{raid.detectedMods?.match(/SAIN/gi) ? 'SAIN' : ''}</th>
+                        <th className="text-center px-2 cursor-pointer hover:bg-black/10" title="Kills" onClick={() => handleSort('kills')}>K{sortIndicator('kills')}</th>
+                        <th className="text-center px-2 cursor-pointer hover:bg-black/10" title="Looted items" onClick={() => handleSort('lootings')}>L{sortIndicator('lootings')}</th>
+                        <th className="text-center px-2 cursor-pointer hover:bg-black/10" title="Accuracy" onClick={() => handleSort('accuracy')}>A%{sortIndicator('accuracy')}</th>
                         <th className={`text-right px-2 underline cursor-pointer ${groupedByType === '' ? 'bg-black text-eft' : ''}`} onClick={() => setGroupedByType('')}>Spawned</th>
                     </tr>
                 </thead>
                 <tbody>
-                    { generatePlayerTable(raid) || <tr><td colSpan={9}>No Data.</td></tr>}
+                    {generatePlayerTable(raid) || <tr><td colSpan={10}>No Data.</td></tr>}
                 </tbody>
             </table>
         </section>

--- a/Private/src/pages/V2/RaidOverview.tsx
+++ b/Private/src/pages/V2/RaidOverview.tsx
@@ -54,14 +54,20 @@ function needsDarkText(hex: string): boolean {
     return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.5;
 }
 
-type SortKey = 'lvl' | 'kills' | 'lootings' | 'accuracy' | null;
+type SortKey = 'lvl' | 'kills' | 'lootings' | 'lootedValue' | 'spawnValue' | 'accuracy' | null;
+
+function formatCompactNumber(n: number): string {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+    return String(n);
+}
 type SortDir = 'asc' | 'desc';
 
 export default function RaidOverview() {
     const { raid, intl: intl_dir_ot } = useOutletContext() as { raid: TrackingRaidData, intl: { [key:string] : string } };
 
 
-    const [ calcStats, setCalcStats ] = useState(null as null | Map<string, { kills: number, lootings: number, accuracy: number }>);
+    const [ calcStats, setCalcStats ] = useState(null as null | Map<string, { kills: number, lootings: number, lootedValue: number, spawnValue: number, accuracy: number }>);
     const [ raidSummary, setRaidSummary ] = useState([] as { title: string; value: any;}[]);
     const [ groupedByType, setGroupedByType ] = useState('TEAM' as string);
     const [ groupedBy, setGroupedBy ] = useState([] as TrackingRaidDataPlayers[][]);
@@ -136,6 +142,15 @@ export default function RaidOverview() {
           let lootingsRemoved = _.filter(filteredLoot, (looter) => looter.profileId === player.profileId && String(looter.added).match(/^(0|false)$/i)).length;
           let lootings = lootingsAdded - lootingsRemoved;
 
+          // Looted value: sum of (price × qty) for added items minus dropped items
+          let lootedValue = 0;
+          for (const loot of filteredLoot) {
+            if (loot.profileId !== player.profileId) continue;
+            const price = Number(loot.price) || 0;
+            const qty = Number(loot.qty) || 1;
+            const isAdded = String(loot.added).match(/^(1|true)$/i);
+            lootedValue += isAdded ? price * qty : -(price * qty);
+          }
 
           let allShots = _.filter(raid.ballistic, (shot) => shot.profileId === player.profileId).length;
           let hitShots = _.filter(raid.ballistic, (shot) => shot.profileId === player.profileId && shot.hitPlayerId).length
@@ -145,9 +160,22 @@ export default function RaidOverview() {
             accuracy = 0;
           }
 
+          // Bot spawn value from player_inventory (exclude non-lootable slots: main, SecuredContainer)
+          let spawnValue = 0;
+          if (raid.player_inventory) {
+            for (const inv of raid.player_inventory) {
+              if (inv.profileId !== player.profileId) continue;
+              const slot = inv.slot || '';
+              if (/^(main|SecuredContainer)$/i.test(slot)) continue;
+              spawnValue += (Number(inv.price) || 0) * (Number(inv.qty) || 1);
+            }
+          }
+
           calculatedStats.set(player.profileId, {
             kills,
             lootings,
+            lootedValue,
+            spawnValue,
             accuracy
           })
         }
@@ -424,6 +452,12 @@ export default function RaidOverview() {
                 <td className="text-right p-2 capitalize">{raid.detectedMods?.match(/SAIN/gi) ? SAIN : ''}</td>
                 <td className="text-center p-2 w-12 border-l border-eft">{stats ? stats.kills || '-' : null}</td>
                 <td className={`text-center p-2 w-12 ${(stats && stats.lootings < 0) ? 'text-red-400' : 'text-green-400'}`}>{stats ? stats.lootings || '-' : null}</td>
+                <td className={`text-center p-2 w-16 text-xs ${stats && stats.lootedValue < 0 ? 'text-red-400' : 'text-yellow-400'}`}>
+                  {stats ? (stats.lootedValue ? formatCompactNumber(stats.lootedValue) : '-') : null}
+                </td>
+                <td className="text-center p-2 w-16 text-xs text-orange-300">
+                  {stats ? (stats.spawnValue ? formatCompactNumber(stats.spawnValue) : '-') : null}
+                </td>
                 <td className="text-center p-2 w-24">
                   {stats ? (
                     <div className="flex items-center justify-center gap-1">
@@ -462,7 +496,7 @@ export default function RaidOverview() {
         <section className="mt-4">
             <div className="w-full flex flex-row justify-between items-center">
               <span className="text-lg font-bold">Leaderboard</span>
-              <span className="text-sm opacity-70">Click row to show kills | Sort by Lvl, K, L, A%</span>
+              <span className="text-sm opacity-70">Click row to show kills | Sort by Lvl, K, L, V, SV, A%</span>
             </div>
             <table id="raid-leaderboard" className="mb-2 w-full border border-eft">
                 <thead>
@@ -475,12 +509,14 @@ export default function RaidOverview() {
                         <th className="text-right px-2">{raid.detectedMods?.match(/SAIN/gi) ? 'SAIN' : ''}</th>
                         <th className="text-center px-2 cursor-pointer hover:bg-black/10" title="Kills" onClick={() => handleSort('kills')}>K{sortIndicator('kills')}</th>
                         <th className="text-center px-2 cursor-pointer hover:bg-black/10" title="Looted items" onClick={() => handleSort('lootings')}>L{sortIndicator('lootings')}</th>
+                        <th className="text-center px-2 cursor-pointer hover:bg-black/10" title="Looted value (₽)" onClick={() => handleSort('lootedValue')}>V{sortIndicator('lootedValue')}</th>
+                        <th className="text-center px-2 cursor-pointer hover:bg-black/10" title="Spawn value (₽)" onClick={() => handleSort('spawnValue')}>SV{sortIndicator('spawnValue')}</th>
                         <th className="text-center px-2 cursor-pointer hover:bg-black/10" title="Accuracy" onClick={() => handleSort('accuracy')}>A%{sortIndicator('accuracy')}</th>
                         <th className={`text-right px-2 underline cursor-pointer ${groupedByType === '' ? 'bg-black text-eft' : ''}`} onClick={() => setGroupedByType('')}>Spawned</th>
                     </tr>
                 </thead>
                 <tbody>
-                    {generatePlayerTable(raid) || <tr><td colSpan={10}>No Data.</td></tr>}
+                    {generatePlayerTable(raid) || <tr><td colSpan={12}>No Data.</td></tr>}
                 </tbody>
             </table>
         </section>

--- a/Private/src/pages/V2/RaidOverview.tsx
+++ b/Private/src/pages/V2/RaidOverview.tsx
@@ -105,13 +105,35 @@ export default function RaidOverview() {
 
     useEffect(() => {
       if (raid && raid.players) {
+        // Filter out internal inventory moves (same player, same itemId, dropped+looted within 1s)
+        const allLoot = (raid.looting || []) as any[]
+        const moveIds = new Set<number>()
+        for (let i = 0; i < allLoot.length; i++) {
+          if (moveIds.has(i)) continue
+          const a = allLoot[i]
+          const aAdded = String(a.added).match(/^(1|true)$/i)
+          for (let j = i + 1; j < allLoot.length; j++) {
+            if (moveIds.has(j)) continue
+            const b = allLoot[j]
+            if (b.profileId !== a.profileId || b.itemId !== a.itemId) continue
+            if (Math.abs(Number(b.time) - Number(a.time)) > 1000) break
+            const bAdded = String(b.added).match(/^(1|true)$/i)
+            if (!!aAdded !== !!bAdded) {
+              moveIds.add(i)
+              moveIds.add(j)
+              break
+            }
+          }
+        }
+        const filteredLoot = allLoot.filter((_, idx) => !moveIds.has(idx))
+
         const calculatedStats = new Map();
         for (let i = 0; i < raid.players.length; i++) {
           const player = raid.players[i];
 
           let kills = _.filter(raid.kills, (killer) => killer.profileId === player.profileId).length;
-          let lootingsAdded = _.filter(raid.looting, (looter) => looter.profileId === player.profileId && looter.added === '1').length;
-          let lootingsRemoved = _.filter(raid.looting, (looter) => looter.profileId === player.profileId && looter.added === '0').length;
+          let lootingsAdded = _.filter(filteredLoot, (looter) => looter.profileId === player.profileId && String(looter.added).match(/^(1|true)$/i)).length;
+          let lootingsRemoved = _.filter(filteredLoot, (looter) => looter.profileId === player.profileId && String(looter.added).match(/^(0|false)$/i)).length;
           let lootings = lootingsAdded - lootingsRemoved;
 
 

--- a/Private/src/pages/V2/RaidOverview.tsx
+++ b/Private/src/pages/V2/RaidOverview.tsx
@@ -35,10 +35,17 @@ const FACTION_COLORS: Record<string, { color: string, label: string }> = {
 };
 
 const SIDE_COLORS: Record<string, { color: string, label: string }> = {
-    'USEC':   { color: '#1E90FF', label: 'USEC' },
+    'Usec':   { color: '#1E90FF', label: 'USEC' },
     'Bear':   { color: '#CD5C5C', label: 'BEAR' },
     'Savage': { color: '#33FF57', label: 'Scav' },
 };
+
+const PMC_TEAM_COLORS = [
+    "#3357FF", "#FFD433", "#33FFF3", "#9370DB", "#BC8F8F",
+    "#FF5733", "#7FFFD4", "#FFFF99", "#ae85f9", "#FF9633",
+    "#3366FF", "#B87333", "#FFA533", "#33FFAF", "#5733FF",
+    "#FF33D4", "#33FFCC", "#FF5733", "#5733FF",
+];
 
 function needsDarkText(hex: string): boolean {
     const r = parseInt(hex.slice(1, 3), 16);
@@ -56,7 +63,7 @@ export default function RaidOverview() {
 
     const [ calcStats, setCalcStats ] = useState(null as null | Map<string, { kills: number, lootings: number, accuracy: number }>);
     const [ raidSummary, setRaidSummary ] = useState([] as { title: string; value: any;}[]);
-    const [ groupedByType, setGroupedByType ] = useState('' as string);
+    const [ groupedByType, setGroupedByType ] = useState('TEAM' as string);
     const [ groupedBy, setGroupedBy ] = useState([] as TrackingRaidDataPlayers[][]);
     const [ sortKey, setSortKey ] = useState<SortKey>(null);
     const [ sortDir, setSortDir ] = useState<SortDir>('desc');
@@ -151,8 +158,25 @@ export default function RaidOverview() {
         }
 
         if (groupedByType === 'TEAM') {
-          const newGrouped = _.chain(raid.players).groupBy('team').valuesIn().value();
-          setGroupedBy([...newGrouped])
+          const SIDE_ORDER = ['Player', 'USEC', 'BEAR', 'P. Scav', 'Boss', 'Goon', 'Follower', 'Raider', 'Rogue', 'Cultist', 'Bloodhound', 'Special', 'Infected', 'Mercenary', 'RUAF', 'UNTAR', 'Black Div', 'Sniper', 'Scav'];
+          const grouped = _.groupBy(raid.players, p => {
+            if (p.profileId === raid.profileId) return 'Player';
+            const isPMC = p.team === 'Usec' || p.team === 'Bear';
+            if (isPMC) {
+              const sideLabel = SIDE_COLORS[p.team]?.label || p.team;
+              return `${sideLabel}#${p.group}`;
+            }
+            const brain = getPlayerBrain(p);
+            if (FACTION_COLORS[brain]) return FACTION_COLORS[brain].label;
+            return SIDE_COLORS[p.team]?.label || p.team;
+          });
+          const sorted = _.sortBy(Object.entries(grouped), ([key]) => {
+            const base = key.split('#')[0];
+            const idx = SIDE_ORDER.indexOf(base);
+            const teamNum = key.includes('#') ? Number(key.split('#')[1]) || 0 : 0;
+            return (idx === -1 ? SIDE_ORDER.length : idx) * 100 + teamNum;
+          });
+          setGroupedBy(sorted.map(([, players]) => players));
         }
       }
 
@@ -305,7 +329,12 @@ export default function RaidOverview() {
         if (FACTION_COLORS[brain]) {
           return FACTION_COLORS[brain];
         }
-        return SIDE_COLORS[player.team] || { color: '#6B7280', label: player.team };
+        const side = SIDE_COLORS[player.team];
+        if (side && (player.team === 'Usec' || player.team === 'Bear')) {
+          const teamColor = PMC_TEAM_COLORS[(player.group ?? 0) % PMC_TEAM_COLORS.length];
+          return { color: teamColor, label: `${side.label} #${player.group}` };
+        }
+        return side || { color: '#6B7280', label: player.team };
       }
 
       function generatePlayerTable(raid: TrackingRaidData) {

--- a/Private/src/pages/V2/RaidTimeline.tsx
+++ b/Private/src/pages/V2/RaidTimeline.tsx
@@ -1,8 +1,9 @@
 import { useOutletContext } from "react-router-dom";
 import { TrackingRaidData } from "../../types/api_types";
 import { bodypart, intl, msToHMS } from "../../helpers";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import _ from "lodash";
+import { getLegendIcon, getPlayerColor, buildPmcIndexMap } from "../../helpers/players";
 
 import cyr_to_en from '../../assets/cyr_to_en.json';
 
@@ -19,6 +20,7 @@ export default function RaidTimeline() {
   };
 
   const intl_dir : Record<string, string> = {...intl_dir_ot, ...cyr_to_en};
+  const pmcIndexMap = useMemo(() => raid?.players ? buildPmcIndexMap(raid.players) : {}, [raid?.players]);
 
   useEffect(() => {
 
@@ -86,9 +88,15 @@ export default function RaidTimeline() {
         });
         combined.sort((a, b) => a.time - b.time);
   
+        const playerIcon = (p: any) => {
+          if (!p || !raid.players) return null
+          const idx = raid.players.indexOf(p)
+          return getLegendIcon(p, getPlayerColor(p, idx), pmcIndexMap[p.profileId])
+        }
+
         return combined.map((tli: any, index) => {
           if (raid.players === undefined) return;
-  
+
           const killer = raid.players.find(
             (player) => player.profileId === tli.profileId
           );
@@ -98,7 +106,7 @@ export default function RaidTimeline() {
           const looter = raid.players.find(
             (player) => player.profileId === tli.profileId
           );
-  
+
           let playerIsFiltered = usernameFilter[tli.profileId];
           if (!playerIsFiltered) return;
 
@@ -108,12 +116,12 @@ export default function RaidTimeline() {
                   <>
                     {/* @ts-ignore */}
                     <td className="opacity-75 px-2 border-r border-eft">{msToHMS(tli.time)}</td>
-                    <td className="text-right pr-2">{killer ? intl(killer.name, intl_dir) : "Unknown"}</td>
+                    <td className="text-right pr-2"><span className="inline-flex items-center">{playerIcon(killer)}{killer ? intl(killer.name, intl_dir) : "Unknown"}</span></td>
                     <td className="text-center px-2 border-l border-r border-eft">
-                      <span className="opacity-75">killed </span>
+                      <span style={{ color: '#EF4444' }}>killed </span>
                     </td>
                     <td className="text-left px-2">
-                      <strong>{killed ? intl(killed.name, intl_dir) : "Unknown"}</strong>
+                      <span className="inline-flex items-center">{playerIcon(killed)}<strong>{killed ? intl(killed.name, intl_dir) : "Unknown"}</strong></span>
                       <span className="opacity-75"> with a </span>
                         {/* @ts-ignore */}
                       <strong>{ intl([tli.weapon.replace("Name", "ShortName")], intl_dir) } [{bodypart[tli.bodyPart]? bodypart[tli.bodyPart]: tli.bodyPart}] [{ Number(tli.distance).toFixed(2) }m]</strong>
@@ -123,9 +131,9 @@ export default function RaidTimeline() {
                   <>
                     {/* @ts-ignore */}
                     <td className="opacity-75 px-2 border-r border-eft">{msToHMS(tli.time)}</td>
-                    <td className="text-right pr-2">{looter ? intl(looter.name, intl_dir) : "Unknown"}</td>
+                    <td className="text-right pr-2"><span className="inline-flex items-center">{playerIcon(looter)}{looter ? intl(looter.name, intl_dir) : "Unknown"}</span></td>
                     <td className="text-center px-2 border-l border-r border-eft">
-                      <span className="opacity-75">
+                      <span style={{ color: String(tli.added).match(/^(1|true)$/i) ? '#22C55E' : '#F59E0B' }}>
                       {String(tli.added).match(/^(1|true)$/i) ? " looted " : " dropped "}
                       </span>{" "}
                     </td>

--- a/Private/src/pages/V2/RaidTimeline.tsx
+++ b/Private/src/pages/V2/RaidTimeline.tsx
@@ -56,7 +56,28 @@ export default function RaidTimeline() {
           combined = [ ...combined, ...raid.kills ];
         }
         if (actionFilter.looting) {
-          combined = [ ...combined, ...raid.looting ]
+          // Filter out internal inventory moves (same player, same itemId, dropped+looted within 1s)
+          const lootItems = raid.looting as any[]
+          const moveIds = new Set<number>()
+          for (let i = 0; i < lootItems.length; i++) {
+            if (moveIds.has(i)) continue
+            const a = lootItems[i]
+            const aAdded = String(a.added).match(/^(1|true)$/i)
+            for (let j = i + 1; j < lootItems.length; j++) {
+              if (moveIds.has(j)) continue
+              const b = lootItems[j]
+              if (b.profileId !== a.profileId || b.itemId !== a.itemId) continue
+              if (Math.abs(Number(b.time) - Number(a.time)) > 1000) break
+              const bAdded = String(b.added).match(/^(1|true)$/i)
+              if (!!aAdded !== !!bAdded) {
+                moveIds.add(i)
+                moveIds.add(j)
+                break
+              }
+            }
+          }
+          const filteredLoot = lootItems.filter((_, idx) => !moveIds.has(idx))
+          combined = [ ...combined, ...filteredLoot ]
         }
   
         combined.map((tli) => {
@@ -105,7 +126,7 @@ export default function RaidTimeline() {
                     <td className="text-right pr-2">{looter ? intl(looter.name, intl_dir) : "Unknown"}</td>
                     <td className="text-center px-2 border-l border-r border-eft">
                       <span className="opacity-75">
-                      {Number(tli.added) ? " looted " : " dropped "}
+                      {String(tli.added).match(/^(1|true)$/i) ? " looted " : " dropped "}
                       </span>{" "}
                     </td>
                     <td className="text-left pl-2">

--- a/Private/src/pages/V2/Raids.css
+++ b/Private/src/pages/V2/Raids.css
@@ -65,6 +65,27 @@ tbody tr:nth-child(even) {
     background: rgba(154, 136, 102, 0.15) !important;
 }
 
+/* Kill highlight: row click interaction */
+#raid-leaderboard tbody tr {
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.leaderboard-selected {
+    outline: 1px solid #9a8866;
+    background: rgba(154, 136, 102, 0.18) !important;
+}
+
+.leaderboard-victim {
+    border-left: 3px solid #22C55E !important;
+    background: rgba(34, 197, 94, 0.08) !important;
+}
+
+.leaderboard-killer {
+    border-left: 3px solid #EF4444 !important;
+    background: rgba(239, 68, 68, 0.08) !important;
+}
+
 /* Sort header hover */
 #raid-leaderboard thead th.cursor-pointer:hover {
     background: rgba(0, 0, 0, 0.15);

--- a/Private/src/pages/V2/Raids.css
+++ b/Private/src/pages/V2/Raids.css
@@ -99,3 +99,5 @@ tbody tr:nth-child(even) {
 .raid-timeline li {
     list-style: none;
 }
+#raid-timeline tbody tr { transition: background 0.1s; }
+#raid-timeline tbody tr:hover { background: rgba(154,136,102,0.15); }

--- a/Private/src/pages/V2/Raids.css
+++ b/Private/src/pages/V2/Raids.css
@@ -18,13 +18,56 @@ tbody tr:nth-child(even) {
     width: 200px;
 }
 
-#raid-leaderboard tbody tr td:nth-of-type(1), #raid-leaderboard tbody tr td:nth-of-type(2), #raid-leaderboard tbody tr td:nth-of-type(3),
-#raid-leaderboard tbody tr td:nth-of-type(6), #raid-leaderboard tbody tr td:nth-of-type(7), #raid-leaderboard tbody tr td:nth-of-type(8) {
+/* Leaderboard: override alternating rows — rely on group tinting instead */
+#raid-leaderboard tbody tr:nth-child(even) {
+    background: transparent;
+}
+
+/* 10-column layout widths */
+#raid-leaderboard tbody tr td:nth-of-type(1) {
+    width: 90px;
+}
+
+#raid-leaderboard tbody tr td:nth-of-type(2),
+#raid-leaderboard tbody tr td:nth-of-type(3) {
+    width: 50px;
+}
+
+#raid-leaderboard tbody tr td:nth-of-type(5) {
+    width: 70px;
+}
+
+#raid-leaderboard tbody tr td:nth-of-type(7),
+#raid-leaderboard tbody tr td:nth-of-type(8) {
     width: 50px;
 }
 
 #raid-leaderboard tbody tr td:nth-of-type(9) {
+    width: 100px;
+}
+
+#raid-leaderboard tbody tr td:nth-of-type(10) {
     width: 105px;
+}
+
+/* Player's own row highlight */
+.leaderboard-player-row {
+    border-left: 3px solid #9a8866 !important;
+    background: rgba(154, 136, 102, 0.12) !important;
+}
+
+/* Alternating group tint */
+.leaderboard-group-alt {
+    background: rgba(154, 136, 102, 0.06);
+}
+
+.leaderboard-group-alt.leaderboard-player-row {
+    background: rgba(154, 136, 102, 0.15) !important;
+}
+
+/* Sort header hover */
+#raid-leaderboard thead th.cursor-pointer:hover {
+    background: rgba(0, 0, 0, 0.15);
 }
 
 #raid-overview input[type="checkbox"] {

--- a/Private/src/types/api_types.d.ts
+++ b/Private/src/types/api_types.d.ts
@@ -19,6 +19,7 @@ export interface TrackingPositionalData {
   y: Number
   z: Number
   dir: Number
+  decision?: string
   created_at: Date
 }
 

--- a/Private/src/types/api_types.d.ts
+++ b/Private/src/types/api_types.d.ts
@@ -87,6 +87,7 @@ export interface TrackingBallistic {
   profileId: string;
   time: number;
   weaponId: string;
+  weaponName?: string;
   ammoId: string;
   hitPlayerId: string;
   source: string;

--- a/Private/src/types/api_types.d.ts
+++ b/Private/src/types/api_types.d.ts
@@ -41,6 +41,7 @@ export interface TrackingRaidData {
   kills?: TrackingRaidDataKills[]
   ballistic?: TrackingBallistic[]
   looting?: TrackingRaidDataLoot[]
+  player_inventory?: TrackingPlayerInventoryItem[]
 }
 
 export interface TrackingRaidDataPlayers {
@@ -70,10 +71,17 @@ export interface TrackingRaidDataLoot {
   profileId: string
   time: number
   id: string
+  itemId: string
   name: string
+  itemName: string
   qty: string
   type: string
   added: string
+  templateId?: string
+  price?: number
+  x?: number
+  y?: number
+  z?: number
 }
 
 export interface TrackingPlayerStatus {
@@ -93,6 +101,28 @@ export interface TrackingBallistic {
   hitPlayerId: string;
   source: string;
   target: string;
+}
+
+export interface TrackingLooseLootItem {
+  itemId: string
+  templateId: string
+  itemName: string
+  price: number
+  qty: number
+  x: number
+  y: number
+  z: number
+  inContainer: boolean | number
+  containerName: string
+}
+
+export interface TrackingPlayerInventoryItem {
+  profileId: string
+  templateId: string
+  itemName: string
+  price: number
+  qty: number
+  slot: string
 }
 
 export interface RaidReviewServerSettings {

--- a/ServerMod/DataIntegrity/GarbageCollector.cs
+++ b/ServerMod/DataIntegrity/GarbageCollector.cs
@@ -10,7 +10,7 @@ public class GarbageCollector
     private readonly DataFileService _fileService;
     private readonly RaidReviewLogger _logger;
     private readonly RaidReviewConfig _config;
-    private const string ActiveVersion = "V3";
+    private const string ActiveVersion = "V4";
 
     public GarbageCollector(DatabaseService db, DataFileService fileService, RaidReviewLogger logger, RaidReviewConfig config)
     {

--- a/ServerMod/DataIntegrity/GarbageCollector.cs
+++ b/ServerMod/DataIntegrity/GarbageCollector.cs
@@ -86,7 +86,7 @@ public class GarbageCollector
 
     private async Task DeleteRaidDataAsync(string raidId)
     {
-        foreach (var table in new[] { "raid", "kills", "looting", "player", "player_status", "ballistic" })
+        foreach (var table in new[] { "raid", "kills", "looting", "player", "player_status", "ballistic", "loose_loot", "player_inventory" })
         {
             await _db.ExecuteAsync($"DELETE FROM {table} WHERE raidId = $raidId",
                 ("$raidId", raidId));

--- a/ServerMod/Database/DatabaseService.cs
+++ b/ServerMod/Database/DatabaseService.cs
@@ -210,6 +210,9 @@ public class DatabaseService : IDisposable
                 DROP TABLE player_status;
                 ALTER TABLE player_status_new RENAME TO player_status;
             "),
+            ("add_ballistic_weapon_name", @"
+                ALTER TABLE ballistic ADD COLUMN ""weaponName"" TEXT DEFAULT '';
+            "),
         };
 
         foreach (var (name, sql) in migrations)

--- a/ServerMod/Database/DatabaseService.cs
+++ b/ServerMod/Database/DatabaseService.cs
@@ -213,6 +213,55 @@ public class DatabaseService : IDisposable
             ("add_ballistic_weapon_name", @"
                 ALTER TABLE ballistic ADD COLUMN ""weaponName"" TEXT DEFAULT '';
             "),
+            ("add_loot_price_columns", @"
+                ALTER TABLE looting ADD COLUMN ""templateId"" TEXT DEFAULT '';
+                ALTER TABLE looting ADD COLUMN ""price"" INTEGER DEFAULT 0;
+            "),
+            ("add_loose_loot_table", @"
+                CREATE TABLE IF NOT EXISTS loose_loot (
+                    ""id"" INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ""raidId"" TEXT NOT NULL,
+                    ""templateId"" TEXT NOT NULL,
+                    ""itemName"" TEXT NOT NULL,
+                    ""price"" INTEGER DEFAULT 0,
+                    ""qty"" INTEGER DEFAULT 1,
+                    ""x"" REAL NOT NULL,
+                    ""y"" REAL NOT NULL,
+                    ""z"" REAL NOT NULL,
+                    ""inContainer"" INTEGER DEFAULT 0,
+                    ""created_at"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (""raidId"") REFERENCES raid(""raidId"")
+                );
+            "),
+            ("add_loose_loot_item_id", @"
+                ALTER TABLE loose_loot ADD COLUMN ""itemId"" TEXT DEFAULT '';
+                ALTER TABLE loose_loot ADD COLUMN ""containerName"" TEXT DEFAULT '';
+            "),
+            ("add_player_inventory_table", @"
+                CREATE TABLE IF NOT EXISTS player_inventory (
+                    ""id"" INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ""raidId"" TEXT NOT NULL,
+                    ""profileId"" TEXT NOT NULL,
+                    ""templateId"" TEXT NOT NULL,
+                    ""itemName"" TEXT NOT NULL,
+                    ""price"" INTEGER DEFAULT 0,
+                    ""qty"" INTEGER DEFAULT 1,
+                    ""slot"" TEXT DEFAULT '',
+                    ""created_at"" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (""raidId"") REFERENCES raid(""raidId"")
+                );
+            "),
+            ("add_loot_position_columns", @"
+                ALTER TABLE looting ADD COLUMN ""x"" REAL DEFAULT 0;
+                ALTER TABLE looting ADD COLUMN ""y"" REAL DEFAULT 0;
+                ALTER TABLE looting ADD COLUMN ""z"" REAL DEFAULT 0;
+            "),
+            ("add_loose_loot_unique_index", @"
+                DELETE FROM loose_loot WHERE rowid NOT IN (
+                    SELECT MIN(rowid) FROM loose_loot GROUP BY raidId, itemId
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_loose_loot_raid_item ON loose_loot(""raidId"", ""itemId"");
+            "),
         };
 
         foreach (var (name, sql) in migrations)

--- a/ServerMod/Http/RaidReviewWebServer.cs
+++ b/ServerMod/Http/RaidReviewWebServer.cs
@@ -279,6 +279,7 @@ public class RaidReviewWebServer
                 var players = await _db.QueryAsync("SELECT * FROM player WHERE raidId = $id", ("$id", raidId));
                 var statuses = await _db.QueryAsync("SELECT * FROM player_status WHERE raidId = $id", ("$id", raidId));
                 var ballistics = await _db.QueryAsync("SELECT * FROM ballistic WHERE raidId = $id", ("$id", raidId));
+                var playerInventory = await _db.QueryAsync("SELECT * FROM player_inventory WHERE raidId = $id", ("$id", raidId));
 
                 var hasCompiledPositions = _fileService.FileExists("positions", "", "", $"{raidId}_{_compiler.ActiveVersion}_positions.json");
                 var hasRawPositions = _fileService.FileExists("positions", "", "", $"{raidId}_positions");
@@ -301,6 +302,7 @@ public class RaidReviewWebServer
                 result["players"] = players;
                 result["player_status"] = statuses;
                 result["ballistic"] = ballistics;
+                result["player_inventory"] = playerInventory;
                 result["positionsTracked"] = positionsTracked;
                 await context.Response.WriteAsJsonAsync(result);
             }
@@ -328,6 +330,20 @@ public class RaidReviewWebServer
             else
             {
                 await context.Response.WriteAsJsonAsync(new object[] { });
+            }
+        });
+
+        app.MapGet("/api/raids/{raidId}/loose_loot", async (HttpContext context, string raidId) =>
+        {
+            try
+            {
+                var data = await _db.QueryAsync("SELECT * FROM loose_loot WHERE raidId = $id", ("$id", raidId));
+                await context.Response.WriteAsJsonAsync(data);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("[API:LOOSE_LOOT]", ex);
+                context.Response.StatusCode = 500;
             }
         });
 
@@ -386,7 +402,7 @@ public class RaidReviewWebServer
 
             foreach (var raidId in raidIds)
             {
-                foreach (var table in new[] { "raid", "kills", "looting", "player", "player_status", "ballistic" })
+                foreach (var table in new[] { "raid", "kills", "looting", "player", "player_status", "ballistic", "loose_loot", "player_inventory" })
                     await _db.ExecuteAsync($"DELETE FROM {table} WHERE raidId = $id", ("$id", raidId));
 
                 _fileService.DeleteFile("positions", "", "", $"{raidId}_positions");

--- a/ServerMod/ModMetadata.cs
+++ b/ServerMod/ModMetadata.cs
@@ -8,7 +8,7 @@ public record ModMetadata : AbstractModMetadata
     public override string Name { get; init; } = "Raid Review";
     public override string Author { get; init; } = "Ekky";
     public override List<string>? Contributors { get; init; } = ["Chazu"];
-    public override SemanticVersioning.Version Version { get; init; } = new("0.5.1");
+    public override SemanticVersioning.Version Version { get; init; } = new("1.0.0");
     public override SemanticVersioning.Range SptVersion { get; init; } = new("~4.0.0");
     public override List<string>? Incompatibilities { get; init; }
     public override Dictionary<string, SemanticVersioning.Range>? ModDependencies { get; init; }

--- a/ServerMod/Models/TrackingModels.cs
+++ b/ServerMod/Models/TrackingModels.cs
@@ -98,4 +98,5 @@ public record PositionalDataEntry
     public string? RaidId { get; set; }
     public float? Health { get; set; }
     public float? MaxHealth { get; set; }
+    public string? Decision { get; set; }
 }

--- a/ServerMod/PostRaid/RaidPositionCompiler.cs
+++ b/ServerMod/PostRaid/RaidPositionCompiler.cs
@@ -7,7 +7,7 @@ namespace RaidReview.PostRaid;
 
 public class RaidPositionCompiler
 {
-    private const string ActiveStructureVersion = "V3";
+    private const string ActiveStructureVersion = "V4";
     private readonly DataFileService _fileService;
     private readonly RaidReviewLogger _logger;
 
@@ -69,6 +69,7 @@ public class RaidPositionCompiler
                     case "raid_id": entry.RaidId = val; break;
                     case "health": if (float.TryParse(val, NumberStyles.Float, CultureInfo.InvariantCulture, out var h)) entry.Health = h; break;
                     case "maxHealth": if (float.TryParse(val, NumberStyles.Float, CultureInfo.InvariantCulture, out var mh)) entry.MaxHealth = mh; break;
+                    case "decision": entry.Decision = val; break;
                 }
             }
             allPositions.Add(entry);

--- a/ServerMod/ServerMod.csproj
+++ b/ServerMod/ServerMod.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
-    <Version>0.5.1</Version>
+    <Version>1.0.0</Version>
     <OutputPath>bin\$(Configuration)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <!-- Copy NuGet runtime deps to output folder -->

--- a/ServerMod/WebSocket/WsPacketHandler.cs
+++ b/ServerMod/WebSocket/WsPacketHandler.cs
@@ -210,11 +210,12 @@ public class WsPacketHandler
                 case "BALLISTIC":
                 {
                     await _db.ExecuteAsync(
-                        "INSERT INTO ballistic (raidId, time, profileId, weaponId, ammoId, hitPlayerId, source, target) VALUES ($raidId, $time, $profileId, $weaponId, $ammoId, $hitPlayerId, $source, $target)",
+                        "INSERT INTO ballistic (raidId, time, profileId, weaponId, weaponName, ammoId, hitPlayerId, source, target) VALUES ($raidId, $time, $profileId, $weaponId, $weaponName, $ammoId, $hitPlayerId, $source, $target)",
                         ("$raidId", raidId!),
                         ("$time", GetString(payload, "time")),
                         ("$profileId", GetString(payload, "profileId")),
                         ("$weaponId", GetString(payload, "weaponId")),
+                        ("$weaponName", GetString(payload, "weaponName")),
                         ("$ammoId", GetString(payload, "ammoId")),
                         ("$hitPlayerId", GetString(payload, "hitPlayerId")),
                         ("$source", GetString(payload, "source")),

--- a/ServerMod/WebSocket/WsPacketHandler.cs
+++ b/ServerMod/WebSocket/WsPacketHandler.cs
@@ -252,14 +252,68 @@ public class WsPacketHandler
                 case "LOOT":
                 {
                     await _db.ExecuteAsync(
-                        "INSERT INTO looting (raidId, profileId, time, qty, itemId, itemName, added) VALUES ($raidId, $profileId, $time, $qty, $itemId, $itemName, $added)",
+                        "INSERT INTO looting (raidId, profileId, time, qty, itemId, itemName, added, templateId, price, x, y, z) VALUES ($raidId, $profileId, $time, $qty, $itemId, $itemName, $added, $templateId, $price, $x, $y, $z)",
                         ("$raidId", raidId!),
                         ("$profileId", GetString(payload, "profileId")),
                         ("$time", GetString(payload, "time")),
                         ("$qty", GetString(payload, "qty")),
                         ("$itemId", GetString(payload, "itemId")),
                         ("$itemName", GetString(payload, "itemName")),
-                        ("$added", GetString(payload, "added")));
+                        ("$added", GetString(payload, "added")),
+                        ("$templateId", GetString(payload, "templateId")),
+                        ("$price", GetString(payload, "price")),
+                        ("$x", GetString(payload, "x")),
+                        ("$y", GetString(payload, "y")),
+                        ("$z", GetString(payload, "z")));
+                    break;
+                }
+
+                case "LOOSE_LOOT":
+                {
+                    if (raidId == null) break;
+                    if (payload.TryGetProperty("items", out var itemsArr) && itemsArr.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var item in itemsArr.EnumerateArray())
+                        {
+                            await _db.ExecuteAsync(
+                                @"INSERT OR IGNORE INTO loose_loot (raidId, itemId, templateId, itemName, price, qty, x, y, z, inContainer, containerName)
+                                  VALUES ($raidId, $itemId, $templateId, $itemName, $price, $qty, $x, $y, $z, $inContainer, $containerName)",
+                                ("$raidId", raidId!),
+                                ("$itemId", GetString(item, "itemId")),
+                                ("$templateId", GetString(item, "templateId")),
+                                ("$itemName", GetString(item, "itemName")),
+                                ("$price", GetString(item, "price")),
+                                ("$qty", GetString(item, "qty")),
+                                ("$x", GetString(item, "x")),
+                                ("$y", GetString(item, "y")),
+                                ("$z", GetString(item, "z")),
+                                ("$inContainer", item.TryGetProperty("inContainer", out var ic) && ic.GetBoolean() ? "1" : "0"),
+                                ("$containerName", GetString(item, "containerName")));
+                        }
+                    }
+                    break;
+                }
+
+                case "PLAYER_INVENTORY":
+                {
+                    if (raidId == null) break;
+                    var profileId2 = GetString(payload, "profileId");
+                    if (payload.TryGetProperty("items", out var invArr) && invArr.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var item in invArr.EnumerateArray())
+                        {
+                            await _db.ExecuteAsync(
+                                @"INSERT INTO player_inventory (raidId, profileId, templateId, itemName, price, qty, slot)
+                                  VALUES ($raidId, $profileId, $templateId, $itemName, $price, $qty, $slot)",
+                                ("$raidId", raidId!),
+                                ("$profileId", profileId2),
+                                ("$templateId", GetString(item, "templateId")),
+                                ("$itemName", GetString(item, "itemName")),
+                                ("$price", GetString(item, "price")),
+                                ("$qty", GetString(item, "qty")),
+                                ("$slot", GetString(item, "slot")));
+                        }
+                    }
                     break;
                 }
             }

--- a/publish.sh
+++ b/publish.sh
@@ -3,7 +3,7 @@ set -e
 
 # Configuration
 default_name="raid_review"
-default_version="0.5.1"
+default_version="1.0.0"
 current_dir=$(pwd)
 
 echo "Let's start the deployment process..."


### PR DESCRIPTION
## Raid Review 1.0.0

Originally created by [Ekky](https://github.com/ekky-llc/spt-raid-review), this 1.0.0 release represents my personal vision for the mod — a complete rework of the UI, new tracking systems, and deep visualization tools built on top of the original foundation.

Changelog since **0.5.1**.

---

### BTR Vehicle Tracking
- Replace generic "BT" square marker with an APC silhouette SVG icon on map and legend
- Classify BTR as "Special" faction instead of Scav, display "(BTR)" label in legend

### Leaderboard Redesign
- Colored faction badges in Side column matching map legend colors (USEC blue, BEAR red, Scav yellow, etc.)
- "Player" badge for main player instead of USEC/BEAR
- Dedicated Status column (KIA/Alive) replacing skull emoji
- Sortable columns: Lvl, K (kills), L (looted), A% (accuracy) with direction indicators
- Accuracy mini progress bars with green/yellow/red thresholds
- Player's own row highlighted with gold left border accent
- Alternating group tinting for visual separation
- 10-column responsive layout

### Kill Relationships
- Click any leaderboard row to highlight their victims (green) and killer (red)
- Dead players show "by KillerName (weapon, distance, bodyPart)" info under their name
- Efficient `killedByMap` lookup from `raid.kills`

### Map Hover Focus & Kill Visualization
- Hover a player (legend or dot) to show enriched tooltip with killfeed (kills made + death info)
- Temporary marker appears at dead player's death position with killfeed tooltip
- Red dashed lines + skull icons connect killer → victim on hover, respecting timeline position
- Legend highlights: green border for victims, red border for killer of hovered player
- Separated focus handling from position renderer to prevent view displacement and flicker
- Refs for victim/killer IDs keep position renderer in sync with focus state

### Loot Tracking Fixes
- Fix `added` field boolean mismatch: client sends `True`/`False`, frontend expected `'1'`/`'0'` — now accepts both formats
- Filter internal inventory moves client-side: buffer removes 50ms and cancel if matching add follows (same itemId = slot swap, not real pickup/drop)
- Frontend fallback filter for existing raid data: deduplicate dropped+looted pairs of same itemId within 1s window
- Applied deduplication to both Timeline and Overview leaderboard loot counts

### Stats Charts Overhaul
- **Active Bots Over Time**: faction breakdown in tooltip (USEC, BEAR, Scav, etc.)
- **Kills Over Time**: killfeed-style tooltip with attacker/victim names and weapon icons
- **Looting Over Time**: tooltip shows player name + item looted
- **Projectiles Over Time**: tooltip shows shooter name + weapon used
- New pie charts: **Bots By Faction**, **PMC Personalities**, **Bots By Difficulty** with player name tooltips and distinct color schemes
- Extract shared player helpers (`getPlayerFaction`, `getPlayerColor`, `getLegendIcon`) into `helpers/players.tsx`, reused across map and charts
- `weaponName` field added to ballistic tracking (C# client capture → DB migration → frontend display)
- Timeline actions color-coded: red for killed, orange for dropped, green for looted

### Bot Behavior Tracking (new)
- Capture bot AI decisions (`BotLogicDecision`) per position tick
- **SAIN integration**: reflect into SAIN's `BotComponent` for detailed decisions (`CurrentCombatDecision`, `CurrentSelfDecision`, `CurrentSquadDecision`, `ActiveLayer`), with vanilla `LastDecision` fallback (filtering BigBrain 9000+ IDs)
- Decision field added to position packets, parsed in position CSV compiler (version V3→V4, forces recompilation of cached JSON)
- 10-category color system: Combat, Search, Movement, Patrol, Medical, Loot, Flee, Extract, Grenade, Other — with 90+ decision-to-category mappings for both vanilla and SAIN enums
- Map overlay: colored rings around bot markers with behavior in tooltips, toggle button (default on with SAIN, off without)
- BTR excluded from behavior data
- SAIN recommendation banner when SAIN not detected

### Bot Behavior Timeline Page (new)
- New `/raid/:raidId/behavior` route with Gantt-style horizontal timeline
- Each bot gets a row, colored bars represent behavior categories over time
- Scroll-to-zoom on timeline with draggable scrollbar
- Pre-spawn and post-death periods shown with hatched pattern
- Human player filtered out, bots sorted by team
- Rewrite SAIN reflection to use `BotManagerComponent.Bots` dictionary cache for performance
- Add `Mover.Moving` / `BotInStandBy` for granular peace-mode states (idle vs patrol)
- Idle category: passive behaviors shown with dim bars and no map ring
- Increased text sizes across right panel, bot behavior legend, and timeline page

### Loot Value Tracking (new)
- Enrich all loot events with `templateId`, `price` (handbook base price), and player position (`x`/`y`/`z`)
- **"Value" column** in leaderboard: sum of handbook prices of looted items per player
- **"Spawn Val." column** in leaderboard: total value of bot inventory at spawn (bots only, excludes non-lootable slots like SecuredContainer/Dogtag/ArmBand)
- Backward compatible: old raids without price data show "—"

### Loose Loot Map Overlay (new)
- Capture all world loot at raid start: ground items + container contents (SPT pre-generates all loot)
- SVG `circleMarker` rendering (not DOM markers) for performance with thousands of items
- Price-tier color coding: gray (<10K), white (10-50K), blue (50-100K), purple (100-500K), gold (>500K)
- Container items grouped by position with combined tooltip listing all contents
- Ground items shown as individual markers with diamond icon
- Dropped items appear as dashed markers at drop position, disappear when picked up (timeline-aware)
- Sidebar "Loose Loot" panel: toggle, price filter slider, ground/container/all filter, item count + total value
- Sortable item list by price, click to pan map to item location
- Hover sidebar item → tooltip + highlight ring on map
- Deduplicated: client-side `HashSet`, DB unique index on `(raidId, itemId)`, `INSERT OR IGNORE`
- Defaults: show on map enabled, min price 50,000₽
- Markers render below bot dots (SVG pane z-index 200 vs marker pane z-index 600)

### Bot Inventory Inspector (new)
- Collapsible "Bot Inventory" panel in map sidebar
- Dropdown to select any bot with inventory data
- Items grouped by slot: Weapons, Armor, Backpack, TacticalVest, Pockets, etc.
- Weapon attachments shown as indented sub-items
- Each item shows name, quantity, and handbook price
- Total spawn value displayed at top

### Infrastructure
- 5 new DB migrations: `weaponName` on kills, `templateId`/`price` on looting, `x`/`y`/`z` position on looting, `loose_loot` table, `player_inventory` table, unique index on loose loot
- Position data version bump V3→V4 to include decision column
- Version bump to 1.0.0 across all components