### PR TITLE
1.0.1: Fika support

### DIFF
--- a/Client/RAID-REVIEW.csproj
+++ b/Client/RAID-REVIEW.csproj
@@ -7,7 +7,7 @@
 		<AssemblyDescription>A post raid review tool for SPT</AssemblyDescription>
 		<AssemblyCompany>EkkyLLC</AssemblyCompany>
 		<AssemblyProduct>RAID_REVIEW</AssemblyProduct>
-		<AssemblyVersion>1.0.0</AssemblyVersion>
+		<AssemblyVersion>1.0.1</AssemblyVersion>
 		<Copyright>2024 © Ekky</Copyright>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<OutputPath>C:\Games\SPT-4.0\BepInEx\plugins\</OutputPath>

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -568,22 +568,48 @@ namespace RAID_REVIEW
 
                     }
 
-                    // IF MAP NOT LOADED, RETURN
+                    // IF MAP NOT LOADED — check if raid ended without OnGameSessionEnd (headless)
                     if (!MapLoaded())
+                    {
+                        if (inRaid)
+                        {
+                            try
+                            {
+                                tracking = false;
+                                inRaid = false;
+                                stopwatch.Stop();
+                                trackingRaid.exitName = trackingRaid.exitName ?? "UNKNOWN";
+                                trackingRaid.time = DateTime.Now;
+                                trackingRaid.timeInRaid = stopwatch.ElapsedMilliseconds;
+
+                                BotChecker.BotCheckLoop(true);
+                                if (SOLARINT_SAIN__DETECTED) _ = SAIN_Integration.CheckForSainComponents(true);
+                                Telemetry.Send("PLAYER_CHECK", JsonConvert.SerializeObject(trackingPlayers.Values));
+                                Telemetry.Send("END", JsonConvert.SerializeObject(trackingRaid));
+                            }
+                            catch { }
+                            finally
+                            {
+                                trackingPlayers = new Dictionary<string, TrackingPlayer>();
+                                sessionId = null;
+                                stopwatch.Reset();
+                            }
+                        }
                         continue;
+                    }
 
                     gameWorld = Singleton<GameWorld>.Instance;
-                    myPlayer = gameWorld?.MainPlayer;
+                    myPlayer = gameWorld?.MainPlayer; // null on Fika headless — that's OK
 
-                    // IF IN MENU, RETURN
-                    if (gameWorld == null || myPlayer == null || gameWorld.LocationId == "hideout")
+                    // IF IN MENU, RETURN (don't require myPlayer — headless has none)
+                    if (gameWorld == null || gameWorld.LocationId == "hideout")
                     {
                         continue;
                     }
 
-                    if (sessionId == null && gameWorld != null && myPlayer != null && gameWorld.CurrentProfileId != null)
+                    if (sessionId == null && gameWorld != null)
                     {
-                        sessionId = gameWorld.CurrentProfileId.ToString();
+                        sessionId = gameWorld.CurrentProfileId?.ToString() ?? myPlayer?.ProfileId;
                     }
 
                     // IF RAID HAS NOT STARTED, RETURN

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -23,7 +23,7 @@ using EFT.Interactive;
 
 namespace RAID_REVIEW
 {
-    [BepInPlugin("ekky.raidreview", "Raid Review", "0.5.1")]
+    [BepInPlugin("ekky.raidreview", "Raid Review", "1.0.1")]
     [BepInDependency("me.sol.sain", BepInDependency.DependencyFlags.SoftDependency)]
     public class RAID_REVIEW : BaseUnityPlugin
     {

--- a/Client/patches/player_onGameSessionEndPatch.cs
+++ b/Client/patches/player_onGameSessionEndPatch.cs
@@ -33,7 +33,9 @@ namespace RAID_REVIEW
                 RAID_REVIEW.trackingRaid.exitName = exitName;
                 RAID_REVIEW.trackingRaid.time = DateTime.Now;
                 RAID_REVIEW.trackingRaid.timeInRaid = RAID_REVIEW.stopwatch.ElapsedMilliseconds;
-                RAID_REVIEW.trackingRaid.type = RAID_REVIEW.myPlayer.Side == EPlayerSide.Savage ? "SCAV" : "PMC";
+                // Use trackingRaid.type already set at raid start (myPlayer may be null on headless)
+                if (RAID_REVIEW.myPlayer != null)
+                    RAID_REVIEW.trackingRaid.type = RAID_REVIEW.myPlayer.Side == EPlayerSide.Savage ? "SCAV" : "PMC";
                 RAID_REVIEW.stopwatch.Reset();
 
                 BotChecker.BotCheckLoop(true);

--- a/Client/patches/player_onGameStartedPatch.cs
+++ b/Client/patches/player_onGameStartedPatch.cs
@@ -29,11 +29,26 @@ namespace RAID_REVIEW
 
                 Logger.LogInfo("RAID_REVIEW :::: INFO :::: RAID Settings Loaded");
 
+                // Ensure sessionId is set (CurrentProfileId can be null on Fika headless clients)
+                if (RAID_REVIEW.sessionId == null)
+                {
+                    RAID_REVIEW.sessionId = RAID_REVIEW.gameWorld?.CurrentProfileId?.ToString()
+                                            ?? RAID_REVIEW.myPlayer?.ProfileId
+                                            ?? __instance.MainPlayer?.ProfileId;
+                }
+
                 // Check for installed mods
                 Integrations.ModCheck();
 
                 RAID_REVIEW.stopwatch.Reset();
                 RAID_REVIEW.stopwatch.Start();
+
+                // Determine raid type — myPlayer may be null on Fika headless clients
+                string raidType = "PMC";
+                if (RAID_REVIEW.myPlayer != null)
+                {
+                    raidType = RAID_REVIEW.myPlayer.Side == EPlayerSide.Savage ? "SCAV" : "PMC";
+                }
 
                 RAID_REVIEW.trackingRaid = new TrackingRaid
                 {
@@ -42,26 +57,30 @@ namespace RAID_REVIEW
                     time = DateTime.Now,
                     detectedMods = RAID_REVIEW.RAID_REVIEW__DETECTED_MODS.Count > 0 ? string.Join(",", RAID_REVIEW.RAID_REVIEW__DETECTED_MODS) : "",
                     location = RAID_REVIEW.gameWorld.LocationId,
-                    type = RAID_REVIEW.myPlayer.Side == EPlayerSide.Savage ? "SCAV" : "PMC",
+                    type = raidType,
                     timeInRaid = RAID_REVIEW.stopwatch.IsRunning ? RAID_REVIEW.stopwatch.ElapsedMilliseconds : 0
                 };
                 Telemetry.Send("START", JsonConvert.SerializeObject(RAID_REVIEW.trackingRaid));
 
-                var newTrackingPlayer = new TrackingPlayer
+                // Only register main player if present (headless has no main player)
+                if (RAID_REVIEW.myPlayer != null)
                 {
-                    sessionId = RAID_REVIEW.sessionId,
-                    profileId = RAID_REVIEW.myPlayer.ProfileId,
-                    name = RAID_REVIEW.myPlayer.Profile.Nickname,
-                    level = RAID_REVIEW.myPlayer.Profile.Info.Level,
-                    team = RAID_REVIEW.myPlayer.Side,
-                    group = 0,
-                    spawnTime = RAID_REVIEW.stopwatch.ElapsedMilliseconds,
-                    type = "HUMAN",
-                    mod_SAIN_brain = "PLAYER",
-                    mod_SAIN_difficulty = ""
-                };
-                RAID_REVIEW.trackingPlayers[newTrackingPlayer.profileId] = newTrackingPlayer;
-                Telemetry.Send("PLAYER", JsonConvert.SerializeObject(newTrackingPlayer));
+                    var newTrackingPlayer = new TrackingPlayer
+                    {
+                        sessionId = RAID_REVIEW.sessionId,
+                        profileId = RAID_REVIEW.myPlayer.ProfileId,
+                        name = RAID_REVIEW.myPlayer.Profile.Nickname,
+                        level = RAID_REVIEW.myPlayer.Profile.Info.Level,
+                        team = RAID_REVIEW.myPlayer.Side,
+                        group = 0,
+                        spawnTime = RAID_REVIEW.stopwatch.ElapsedMilliseconds,
+                        type = "HUMAN",
+                        mod_SAIN_brain = "PLAYER",
+                        mod_SAIN_difficulty = ""
+                    };
+                    RAID_REVIEW.trackingPlayers[newTrackingPlayer.profileId] = newTrackingPlayer;
+                    Telemetry.Send("PLAYER", JsonConvert.SerializeObject(newTrackingPlayer));
+                }
 
                 RAID_REVIEW.inRaid = true;
                 RAID_REVIEW.ResetLooseLootFlag();
@@ -69,7 +88,7 @@ namespace RAID_REVIEW
 
                 if (RAID_REVIEW.RecordingNotification.Value && RAID_REVIEW.WebSocketConnected)
                 {
-                    NotificationManagerClass.DisplayMessageNotification("Raid Review Recording Started", ENotificationDurationType.Long);
+                    try { NotificationManagerClass.DisplayMessageNotification("Raid Review Recording Started", ENotificationDurationType.Long); } catch { }
                 }
 
                 if (RAID_REVIEW.SOLARINT_SAIN__DETECTED)

--- a/Private/src/pages/V2/RaidBehaviorTimeline.tsx
+++ b/Private/src/pages/V2/RaidBehaviorTimeline.tsx
@@ -222,7 +222,7 @@ export default function RaidBehaviorTimeline() {
     if (playerRows.length === 0) {
         return (
             <div className="p-4 text-eft text-center opacity-50" style={{ fontSize: '14px' }}>
-                No behavior data available. Play a raid with the updated 1.0.0 mod to capture bot decisions.
+                No behavior data available. Play a raid with the updated mod to capture bot decisions.
             </div>
         )
     }

--- a/ServerMod/ModMetadata.cs
+++ b/ServerMod/ModMetadata.cs
@@ -8,7 +8,7 @@ public record ModMetadata : AbstractModMetadata
     public override string Name { get; init; } = "Raid Review";
     public override string Author { get; init; } = "Ekky";
     public override List<string>? Contributors { get; init; } = ["Chazu"];
-    public override SemanticVersioning.Version Version { get; init; } = new("1.0.0");
+    public override SemanticVersioning.Version Version { get; init; } = new("1.0.1");
     public override SemanticVersioning.Range SptVersion { get; init; } = new("~4.0.0");
     public override List<string>? Incompatibilities { get; init; }
     public override Dictionary<string, SemanticVersioning.Range>? ModDependencies { get; init; }

--- a/ServerMod/ServerMod.csproj
+++ b/ServerMod/ServerMod.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <OutputPath>bin\$(Configuration)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <!-- Copy NuGet runtime deps to output folder -->

--- a/publish.sh
+++ b/publish.sh
@@ -3,7 +3,7 @@ set -e
 
 # Configuration
 default_name="raid_review"
-default_version="1.0.0"
+default_version="1.0.1"
 current_dir=$(pwd)
 
 echo "Let's start the deployment process..."


### PR DESCRIPTION
## Summary
- Add Fika support: handle the case where `MainPlayer` is always null
- Add fallback raid end detection when `Player.OnGameSessionEnd` never fires on headless
- Guard all `myPlayer` access with null checks across the raid lifecycle