### PR TITLE
Update publish script to build and package for multiple architectures.

### DIFF
--- a/Client/RAID-REVIEW.sln
+++ b/Client/RAID-REVIEW.sln
@@ -12,14 +12,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x86 = Debug|x86
-		Release|x86 = Release|x86
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6216F5F2-5841-45CE-AEC5-D78D359591D8}.Debug|x86.ActiveCfg = Debug|x86
-		{6216F5F2-5841-45CE-AEC5-D78D359591D8}.Debug|x86.Build.0 = Debug|x86
-		{6216F5F2-5841-45CE-AEC5-D78D359591D8}.Release|x86.ActiveCfg = Release|x86
-		{6216F5F2-5841-45CE-AEC5-D78D359591D8}.Release|x86.Build.0 = Release|x86
+		{6216F5F2-5841-45CE-AEC5-D78D359591D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6216F5F2-5841-45CE-AEC5-D78D359591D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6216F5F2-5841-45CE-AEC5-D78D359591D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6216F5F2-5841-45CE-AEC5-D78D359591D8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ServerMod/ServerMod.csproj
+++ b/ServerMod/ServerMod.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="SPTarkov.Server.Core" Version="4.0.5" ExcludeAssets="runtime" />
     <!-- SQLite — use winsqlite3.dll (built into Windows 10/11) to avoid native DLL path issues -->
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.0" />
-    <PackageReference Include="SQLitePCLRaw.bundle_winsqlite3" Version="2.1.10" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" />
   </ItemGroup>
 
   <!-- Embed the React frontend INTO the DLL (avoids .js files in the mod folder,

--- a/publish.sh
+++ b/publish.sh
@@ -24,8 +24,8 @@ IFS=',' read -ra ARCH_ARRAY <<< "$target_archs"
 
 clear
 
+rm -rf dist/*
 dist_folder="dist/${name}_${version}"
-rm -rf "$dist_folder"
 
 # 1. Build frontend
 echo ">> Building frontend..."
@@ -60,11 +60,11 @@ fi
 echo "  Client mod output path: $output_path"
 
 # 4. Gather files into structure for distribution and create ZIP archives.
-# - a. Copy the server mod files for each architecture into the appropriate structure for SPT server mods.
+# - a. Copy the server mod files for the architecture into the appropriate structure for an SPT server mod (specified in the server_mod_structure variable below)
 #     - The server mod files include the main mod DLL and any additional DLLs or native libraries it depends on (except those already included in SPT server).
-# - b. Copy server mod config for each architecture (same config for all architectures, but we want it in each distribution)
-# - c. Copy the client mod DLL into the appropriate structure for SPT client mods.
-# - d. Create a ZIP archive for each architecture.
+# - b. Copy the client mod DLL into the appropriate structure for an SPT client mod (specified in the client_mod_structure variable below).
+#     - The client mod is the same for all architectures, but we want it included in each distribution ZIP.
+# - c. Create a ZIP archive for each architecture.
 server_mod_structure="SPT/user/mods/RaidReview"
 client_mod_structure="BepInEx/plugins"
 
@@ -75,31 +75,19 @@ for arch in "${ARCH_ARRAY[@]}"; do
     echo "  Copying $arch server mod files for distribution..."
     server_dest="$dist_folder/$arch/$server_mod_structure"
     mkdir -p $server_dest
-    
-    src_dir="ServerMod/bin/Release/RaidReview/$arch/"
-    find "$src_dir" -type f \( -name "*.dll" -o -name "*.so" -o -name "*.dylib" \) -exec cp {} "$server_dest/" \;
+    cp -r "ServerMod/bin/Release/RaidReview/$arch/"/* "$server_dest/"
 
-    # Copy DLLs flat (must be next to RaidReview.dll — .NET resolves them before any mod code runs)
-    for f in ServerMod/bin/Release/RaidReview/$arch/*.dll; do
-        base=$(basename "$f")
-        case "$base" in
-            SPTarkov.*|SemanticVersioning.*|JetBrains.*) continue ;;   # Already in SPT server
-            *) cp "$f" "$server_dest/" ;;
-        esac
-    done
+    # Remove unnecessary files
+    find "$server_dest" -type f ! \( -name "*.dll" -o -name "*.so" -o -name "*.dylib" \) -delete
+    find "$server_dest" \( -name "SPTarkov.*" -o -name "SemanticVersioning.*" -o -name "JetBrains.*" \) -delete
 
-    # 4b. Copy server mod config
-    echo "  Copying server mod config for $arch distribution..."
-    mkdir -p "$server_dest/config"
-    cp "ServerMod/config/config.json" "$server_dest/config/"
-
-    # 4c. Copy the client mod to each architecture distribution folder. The client mod is the same for all architectures, but we want it in each distribution
+    # 4b. Copy the client mod to each architecture distribution folder.
     echo "  Copying client mod files for $arch distribution..."
     client_dest="$dist_folder/$arch/$client_mod_structure"
-    mkdir -p "$client_dest"
+    mkdir -p $client_dest
     cp "$output_path"/RAID_REVIEW.dll "$client_dest/"
 
-    # 4d Create ZIP archive
+    # 4c. Create ZIP archive
     echo "  Creating archive for $arch distribution..."
     cd "$dist_folder/$arch"
     powershell -Command "Compress-Archive -Force -Path '*' -DestinationPath \"../../${name}__${version}__${arch}.zip\"" > /dev/null
@@ -108,7 +96,7 @@ done
 
 # 5. Cleanup
 echo ">> Cleaning up temporary distribution folders..."
-# rm -rf "$dist_folder"
+rm -rf "$dist_folder"
 
 echo ""
 echo "Finished! The following archives were created and are ready to be published:"

--- a/publish.sh
+++ b/publish.sh
@@ -6,17 +6,25 @@ default_name="raid_review"
 default_version="1.0.1"
 current_dir=$(pwd)
 
-echo "Let's start the deployment process..."
-
+# Get user input for the build and publish configuration
+echo "Let's start the deployment process... (hit Enter to accept defaults)"
 read -p "Please enter the name of your Mod [$default_name]: " name
 name=${name:-$default_name}
 
 read -p "Please enter the version number of your Mod [$default_version]: " version
 version=${version:-$default_version}
 
+# Ask for target architectures
+echo "Available architectures: linux-x64, linux-arm64, osx-x64, osx-arm64, win-x64, win-arm64"
+read -p "Enter target architectures (comma-separated, default: linux-x64,win-x64): " target_archs
+target_archs=${target_archs:-"linux-x64,win-x64"}
+
+# Parse architectures into array
+IFS=',' read -ra ARCH_ARRAY <<< "$target_archs"
+
 clear
 
-dist_folder="dist/${name}__${version}"
+dist_folder="dist/${name}_${version}"
 rm -rf "$dist_folder"
 
 # 1. Build frontend
@@ -26,10 +34,15 @@ npm install --silent
 npm run build
 cd "$current_dir"
 
-# 2. Build server mod (embeds frontend into DLL)
-echo ">> Building server mod..."
+# 2. Build server mod for each target architecture. This embeds frontend into DLL
+echo ">> Building server mod for architectures: ${ARCH_ARRAY[*]}"
 cd ServerMod
-dotnet build -c Release --nologo -v q
+
+# Build for each architecture
+for arch in "${ARCH_ARRAY[@]}"; do
+    echo "  Building for $arch..."
+    dotnet build -c Release --nologo -v q -r $arch
+done
 cd "$current_dir"
 
 # 3. Build client mod
@@ -38,49 +51,67 @@ cd Client
 dotnet build -c Release --nologo -v q
 cd "$current_dir"
 
-# 4. Package server mod
-echo ">> Packaging server mod..."
-server_dest="$dist_folder/SPT/user/mods/RaidReview"
-mkdir -p "$server_dest"
-
-# Copy DLLs flat (must be next to RaidReview.dll — .NET resolves them before any mod code runs)
-for f in ServerMod/bin/Release/RaidReview/*.dll; do
-    base=$(basename "$f")
-    case "$base" in
-        SPTarkov.*|SemanticVersioning.*|JetBrains.*) continue ;;   # Already in SPT server
-        *) cp "$f" "$server_dest/" ;;
-    esac
-done
-
-# Copy config
-mkdir -p "$server_dest/config"
-cp "ServerMod/config/config.json" "$server_dest/config/"
-
-# 5. Package client mod
-echo ">> Packaging client mod..."
-client_dest="$dist_folder/BepInEx/plugins"
-mkdir -p "$client_dest"
-
-# Read OutputPath from the csproj (handles custom paths like C:\Games\SPT-4.0\BepInEx\plugins\)
+# Find the client output path in order to copy the client mod DLL to the distribution folders.
+# Read the OutputPath from the csproj to handle any custom paths specified in the project file. If a custom path is not found, default to Client/bin/Release
 output_path=$(sed -n 's/.*<OutputPath>\(.*\)<\/OutputPath>.*/\1/p' Client/RAID-REVIEW.csproj | head -1 | tr -d '\r' | sed 's/\s*$//')
 if [ -z "$output_path" ]; then
     output_path="Client/bin/Release"
 fi
-for file in "$output_path"/RAID_REVIEW.dll; do
-    if [ -f "$file" ]; then
-        echo "  Copying $(basename "$file") from $output_path"
-        cp "$file" "$client_dest/"
-    fi
+echo "  Client mod output path: $output_path"
+
+# 4. Gather files into structure for distribution and create ZIP archives.
+# - a. Copy the server mod files for each architecture into the appropriate structure for SPT server mods.
+#     - The server mod files include the main mod DLL and any additional DLLs or native libraries it depends on (except those already included in SPT server).
+# - b. Copy server mod config for each architecture (same config for all architectures, but we want it in each distribution)
+# - c. Copy the client mod DLL into the appropriate structure for SPT client mods.
+# - d. Create a ZIP archive for each architecture.
+server_mod_structure="SPT/user/mods/RaidReview"
+client_mod_structure="BepInEx/plugins"
+
+for arch in "${ARCH_ARRAY[@]}"; do
+    echo ">> Packaging mod for $arch..."
+    
+    # 4a. Copy the server mod release builds for each architecture.
+    echo "  Copying $arch server mod files for distribution..."
+    server_dest="$dist_folder/$arch/$server_mod_structure"
+    mkdir -p $server_dest
+    
+    src_dir="ServerMod/bin/Release/RaidReview/$arch/"
+    find "$src_dir" -type f \( -name "*.dll" -o -name "*.so" -o -name "*.dylib" \) -exec cp {} "$server_dest/" \;
+
+    # Copy DLLs flat (must be next to RaidReview.dll — .NET resolves them before any mod code runs)
+    for f in ServerMod/bin/Release/RaidReview/$arch/*.dll; do
+        base=$(basename "$f")
+        case "$base" in
+            SPTarkov.*|SemanticVersioning.*|JetBrains.*) continue ;;   # Already in SPT server
+            *) cp "$f" "$server_dest/" ;;
+        esac
+    done
+
+    # 4b. Copy server mod config
+    echo "  Copying server mod config for $arch distribution..."
+    mkdir -p "$server_dest/config"
+    cp "ServerMod/config/config.json" "$server_dest/config/"
+
+    # 4c. Copy the client mod to each architecture distribution folder. The client mod is the same for all architectures, but we want it in each distribution
+    echo "  Copying client mod files for $arch distribution..."
+    client_dest="$dist_folder/$arch/$client_mod_structure"
+    mkdir -p "$client_dest"
+    cp "$output_path"/RAID_REVIEW.dll "$client_dest/"
+
+    # 4d Create ZIP archive
+    echo "  Creating archive for $arch distribution..."
+    cd "$dist_folder/$arch"
+    powershell -Command "Compress-Archive -Force -Path '*' -DestinationPath \"../../${name}__${version}__${arch}.zip\"" > /dev/null
+    cd "$current_dir"
 done
 
-# 6. Create ZIP
-echo ">> Creating distribution archive..."
-cd "$dist_folder"
-powershell -Command "Compress-Archive -Force -Path '*' -DestinationPath '../${name}__${version}_windows.zip'" > /dev/null
-cd "$current_dir"
-
-# Cleanup
-rm -rf "$dist_folder"
+# 5. Cleanup
+echo ">> Cleaning up temporary distribution folders..."
+# rm -rf "$dist_folder"
 
 echo ""
-echo "Finished! Archive: dist/${name}__${version}_windows.zip"
+echo "Finished! The following archives were created and are ready to be published:"
+for arch in "${ARCH_ARRAY[@]}"; do
+    echo "  dist/${name}__${version}__${arch}.zip"
+done

--- a/publish.sh
+++ b/publish.sh
@@ -59,7 +59,7 @@ if [ -z "$output_path" ]; then
 fi
 echo "  Client mod output path: $output_path"
 
-# 4. Gather files into structure for distribution and create ZIP archives.
+# 4. Gather files for each architecture into the required structure for distribution and create ZIP archives.
 # - a. Copy the server mod files for the architecture into the appropriate structure for an SPT server mod (specified in the server_mod_structure variable below)
 #     - The server mod files include the main mod DLL and any additional DLLs or native libraries it depends on (except those already included in SPT server).
 # - b. Copy the client mod DLL into the appropriate structure for an SPT client mod (specified in the client_mod_structure variable below).
@@ -77,8 +77,10 @@ for arch in "${ARCH_ARRAY[@]}"; do
     mkdir -p $server_dest
     cp -r "ServerMod/bin/Release/RaidReview/$arch/"/* "$server_dest/"
 
-    # Remove unnecessary files
-    find "$server_dest" -type f ! \( -name "*.dll" -o -name "*.so" -o -name "*.dylib" \) -delete
+    # Remove unnecessary files (keep server libs + config)
+    find "$server_dest" -type f ! -path "$server_dest/config/*" ! \( -name "*.dll" -o -name "*.so" -o -name "*.dylib" \) -delete
+    # Remove native runtime DLLs from the root folder to avoid the SPT mod loader treating them as managed assemblies. Keeps .so/.dylib for Linux/macOS.
+    rm -f "$server_dest"/e_sqlite3.dll "$server_dest"/libe_sqlite3.dll
     find "$server_dest" \( -name "SPTarkov.*" -o -name "SemanticVersioning.*" -o -name "JetBrains.*" \) -delete
 
     # 4b. Copy the client mod to each architecture distribution folder.


### PR DESCRIPTION
This PR is to build a distribution of the server mod that can run on an SPT server running on linux. It should resolve #1 (and its duplicate #10).

Feel free to be blunt in your feedback, I won't take offense 😃. Also, I go by FriedEngineer in Discord (I'm in the SPT, Fika, and Raid Review servers); feel free to @ me there if you want to chat.

# Issue
When the SPT server is started on a Linux host with the Raid Review server mod installed, the server crashes (example crash from #10):

<details><summary>Server Logs</summary>
<p>

```
fika-server-1  | [RAID-REVIEW] Raid Review mod loading...
fika-server-1  | Logger queue caught exception: System.OperationCanceledException: The operation was canceled.
fika-server-1  |    at System.Threading.CancellationToken.ThrowOperationCanceledException()
fika-server-1  |    at System.Threading.CancellationToken.ThrowIfCancellationRequested()
fika-server-1  |    at System.Collections.Concurrent.BlockingCollection`1.TryTakeWithNoTimeValidation(T& item, Int32 millisecondsTimeout, CancellationToken cancellationToken, CancellationTokenSource combinedTokenSource)
fika-server-1  |    at System.Collections.Concurrent.BlockingCollection`1.GetConsumingEnumerable(CancellationToken cancellationToken)+MoveNext()
fika-server-1  |    at SPTarkov.Server.Core.Utils.Logger.SptLoggerQueueManager.LoggerWorkerThread()
fika-server-1  | =========================================================================================================
fika-server-1  | The server has unexpectedly stopped, reach out to #mod-questions-4-0 in our Discord server. Include a screenshot of this message and the surrounding error(s) above and below
fika-server-1  | System.DllNotFoundException: Unable to load shared library 'winsqlite3' or one of its dependencies. In order to help diagnose loading problems, consider using a tool like strace. If you're using glibc, consider setting the LD_DEBUG environment variable: 
fika-server-1  | /usr/share/dotnet/shared/Microsoft.NETCore.App/9.0.13/winsqlite3.so: cannot open shared object file: No such file or directory
fika-server-1  | /opt/server/SPT/user/mods/RaidReview/winsqlite3.so: cannot open shared object file: No such file or directory
fika-server-1  | /usr/share/dotnet/shared/Microsoft.NETCore.App/9.0.13/libwinsqlite3.so: cannot open shared object file: No such file or directory
fika-server-1  | /opt/server/SPT/user/mods/RaidReview/libwinsqlite3.so: cannot open shared object file: No such file or directory
fika-server-1  | /usr/share/dotnet/shared/Microsoft.NETCore.App/9.0.13/winsqlite3: cannot open shared object file: No such file or directory
fika-server-1  | /opt/server/SPT/user/mods/RaidReview/winsqlite3: cannot open shared object file: No such file or directory
fika-server-1  | /usr/share/dotnet/shared/Microsoft.NETCore.App/9.0.13/libwinsqlite3: cannot open shared object file: No such file or directory
fika-server-1  | /opt/server/SPT/user/mods/RaidReview/libwinsqlite3: cannot open shared object file: No such file or directory
fika-server-1  | 
fika-server-1  |    at SQLitePCL.SQLite3Provider_winsqlite3.NativeMethods.sqlite3_libversion_number()
fika-server-1  |    at SQLitePCL.SQLite3Provider_winsqlite3.NativeMethods.sqlite3_libversion_number()
fika-server-1  |    at SQLitePCL.SQLite3Provider_winsqlite3.SQLitePCL.ISQLite3Provider.sqlite3_libversion_number()
fika-server-1  |    at SQLitePCL.raw.SetProvider(ISQLite3Provider imp)
fika-server-1  |    at SQLitePCL.Batteries_V2.Init()
fika-server-1  |    at RaidReview.Database.DatabaseService.InitializeAsync(String dataFolder)
fika-server-1  |    at RaidReview.RaidReviewMod.OnLoad()
fika-server-1  |    at SPTarkov.Server.Core.Utils.App.InitializeAsync()
fika-server-1  |    at SPTarkov.Server.Services.SptServerStartupService.Startup()
fika-server-1  |    at SPTarkov.Server.Program.StartServer(String[] args)
fika-server-1  |    at SPTarkov.Server.Program.Main(String[] args)
fika-server-1  | =========================================================================================================
```

</p>
</details> 

# Fix

I basically just followed @jkbbwr's suggestions in #1 to use a different sqlite3 package and to include the relevant library dependency. I don't think the suggestion of `mv Config config` is necessary as the build script already uses `config`. This obviously makes no mod code changes.

## Per-File Change Details

### `publish.sh`
The majority of the changes are here. The high level changes are 
- build the server mod explicitly for a given list of architectures.
  - When `dotnet build -c Release --nologo -v q -r linux-x64` is run, it sets up the release files, including the dependencies, exactly how linux-x64 needs it (and the same when win-x64 or any other architecture is specified). By default I believe it just uses the architecture of the system on which the build is being run, so this just makes it all explicit (and more agnostic to the host system)
- package the server and client mod in a zip for distribution for each architecture
  - The client mod is the same in each, just the server mod is different.

There are some opinionated changes in the refactoring, mostly for things I thought could be reasonably simplified:
- copy the entire server mod release build and then remove the unnecessary files (instead of just copying the necessary files and putting it back into the necessary structure)
-  Just do a one-line copy of the client mod `RAID_REVIEW.dll`. 
    - I suspect the `for file in "$output_path"/RAID_REVIEW.dll` with an `if [ -f "$file" ]` inside is a holdover from a previous version of raid review. It seems overkill for what I think could be accomplished with `cp "$output_path"/RAID_REVIEW.dll "$client_dest/"`

I know support for running the SPT server on arm-x64 is in the works in https://github.com/zhliau/fika-spt-server-docker/issues/33 so part of the reason for the refactoring the build and packaging into loops for specified architectures is so that we can easily add distributions for additional architectures in the future (and anyone could build it now with what's already here).

### `RAID-REVIEW.sln`
I modified the `RAID-REVIEW.sln` to target `Any CPU` instead of `x86` so that the build files are actually in `Client/bin/Release`, as the publish script expects them, otherwise they'd be in `Client/bin/Release/x86`. Most other SPT clients mods I've seen also use `Any CPU` and the dll produced worked as expected in my testing.

I have some additional thoughts about the hardcoded output file and dependency references paths that I'll put into another PR.

### `ServerMod.csproj`
This is just to change the sqlite3 package used from `bundle_winsqlite3` to `bundle_e_sqlite3`

# Testing/Validation
The `publish.sh` script will now (by default) produce 2 zip files for distribution:
- `raid_review__1.0.1__linux-x64.zip`
- `raid_review__1.0.1__win-x64.zip`

Each includes the server mod for the specified architecture and the client mod (same for both)

## Running on Linux
I tested using https://github.com/zhliau/fika-spt-server-docker, which is what I use and I think most people who would use this will be running.

The logs now look exactly as they do on a server running windows. I haven't encountered the crashes they found but I did do some basic testing and verified the following:
- the server now starts without and sqlite3 error
- raids are recorded
- the Raid Review web interface loads and can play back raids

<details><summary>Server Logs</summary>
<p>

```
sptarkov-dev-backend  | Validating SPT version
sptarkov-dev-backend  | Found server files, skipping init
sptarkov-dev-backend  | Setting listen all networks in Fika SPT config override
sptarkov-dev-backend  | Fika server mod already exists, skipping installation
sptarkov-dev-backend  | Downloading and installing other mods
sptarkov-dev-backend  |   No new urls. Nothing to download
sptarkov-dev-backend  | Checking running user/group: 1001:989
sptarkov-dev-backend  | id: '1001': no such user
sptarkov-dev-backend  | User not found, creating user 'spt' with id 1001
sptarkov-dev-backend  | Changing owner of serverfiles to 1001:989
sptarkov-dev-backend  | Changing permissions of server files to user+rwx, group+rwx, others+rx
sptarkov-dev-backend  | Timezone set to US/Mountain
sptarkov-dev-backend  | ModLoader: loading: 3 server mods...
sptarkov-dev-backend  | Mod: Raid Review version: 1.0.1 (GUID: com.ekky.raid-review | targets SPT: ~4.0.0) by: Ekky loaded
sptarkov-dev-backend  | Mod: server version: 2.2.1 (GUID: Fika | targets SPT: >=4.0.11) by: Fika loaded
sptarkov-dev-backend  | Mod: NarcoNet version: 1.0.2 (GUID: com.madmanbeavis.narconet.server | targets SPT: ~4.0.0) by: MadManBeavis loaded
sptarkov-dev-backend  | Loading OnWebAppBuildMods...
sptarkov-dev-backend  | [Fika Server] Overriding SPT configuration
sptarkov-dev-backend  | Finished loading OnWebAppBuildMods...
sptarkov-dev-backend  | Loaded self-signed certificate (./user/certs/server.crt)
sptarkov-dev-backend  | Server: executing startup callbacks...
sptarkov-dev-backend  | ┌─────────────────────────────────────────┐
sptarkov-dev-backend  | │ SPT 4.0.13                              │
sptarkov-dev-backend  | │ https://discord.sp-tarkov.com           │
sptarkov-dev-backend  | │                                         │
sptarkov-dev-backend  | │ This work is free of charge             │
sptarkov-dev-backend  | │ If you paid money, you were scammed     │
sptarkov-dev-backend  | │ Commercial use is prohibited            │
sptarkov-dev-backend  | └─────────────────────────────────────────┘
sptarkov-dev-backend  | Loading PreSptMods...
sptarkov-dev-backend  | Detecting file changes since last startup...
sptarkov-dev-backend  | Loaded changelog with 12 entries, current sequence: 12
sptarkov-dev-backend  | Loaded snapshot with 12 files at sequence 12
sptarkov-dev-backend  | No file changes detected
sptarkov-dev-backend  | Change detection completed in 48ms
sptarkov-dev-backend  | NarcoNet server mod loaded successfully
sptarkov-dev-backend  | Finished loading PreSptMods...
sptarkov-dev-backend  | [RAID-REVIEW] Initializing Raid Review mod...
sptarkov-dev-backend  | [RAID-REVIEW] Config loaded. WS port: 7828, HTTP port: 7829
sptarkov-dev-backend  | [RAID-REVIEW] New log file created: '/opt/server/SPT/user/mods/RaidReview/data/logs/1773638557911_raid_review.log'
sptarkov-dev-backend  | [RAID-REVIEW] Raid Review mod loading...
sptarkov-dev-backend  | [RAID-REVIEW] Database initialized.
sptarkov-dev-backend  | [RAID-REVIEW] Garbage collector deleting old raids, only keeping data for the last '30' raids.
sptarkov-dev-backend  | [RAID-REVIEW] All good, no old raids to purge.
sptarkov-dev-backend  | [RAID-REVIEW] Garbage collector deleting unfinished raids.
sptarkov-dev-backend  | [RAID-REVIEW] All good, no unfinished raids to purge.
sptarkov-dev-backend  | [RAID-REVIEW] Raid Review mod loaded successfully.
sptarkov-dev-backend  | [RAID-REVIEW] Mod loaded successfully.
sptarkov-dev-backend  | Importing database...
sptarkov-dev-backend  | [RAID-REVIEW] WebSocket Server listening on 'ws://127.0.0.1:7828'.
sptarkov-dev-backend  | [RAID-REVIEW] HTTP Web Server running at 'http://127.0.0.1:7829'.
sptarkov-dev-backend  | Database import finished
sptarkov-dev-backend  | Generating flea offers...
sptarkov-dev-backend  | Started webserver at https://0.0.0.0:6969
sptarkov-dev-backend  | Started websocket at wss://0.0.0.0:6969
sptarkov-dev-backend  | Server has started, happy playing
sptarkov-dev-backend  | [Client Request] /launcher/ping
```

## Running on Windows
The only change in the distribution files is the inclusion of `SQLitePCLRaw.provider.e_sqlite3` instead of `SQLitePCLRaw.provider.winsqlite3.dll`. The server runs identically on Windows as far as I can tell:

```
ModLoader: loading: 1 server mods...
Mod: Raid Review version: 1.0.1 (GUID: com.ekky.raid-review | targets SPT: ~4.0.0) by: Ekky loaded
Loading OnWebAppBuildMods...
Finished loading OnWebAppBuildMods...
Loaded self-signed certificate (./user/certs/server.crt)
Server: executing startup callbacks...
┌─────────────────────────────────────────┐
│ SPT 4.0.13                              │
│ https://discord.sp-tarkov.com           │
│                                         │
│ This work is free of charge             │
│ If you paid money, you were scammed     │
│ Commercial use is prohibited            │
└─────────────────────────────────────────┘
Loading PreSptMods...
Finished loading PreSptMods...
[RAID-REVIEW] Initializing Raid Review mod...
[RAID-REVIEW] Config loaded. WS port: 7828, HTTP port: 7829
[RAID-REVIEW] New log file created: 'C:\Users\Rob\Documents\Applications\SPTarkov\Dev\SPT-4\SPT\user\mods\RaidReview\data\logs\1773638798103_raid_review.log'
[RAID-REVIEW] Raid Review mod loading...
[RAID-REVIEW] Database initialized.
[RAID-REVIEW] Garbage collector deleting old raids, only keeping data for the last '30' raids.
[RAID-REVIEW] All good, no old raids to purge.
[RAID-REVIEW] Garbage collector deleting unfinished raids.
[RAID-REVIEW] All good, no unfinished raids to purge.
[RAID-REVIEW] Raid Review mod loaded successfully.
[RAID-REVIEW] Mod loaded successfully.
Importing database...
[RAID-REVIEW] WebSocket Server listening on 'ws://127.0.0.1:7828'.
[RAID-REVIEW] HTTP Web Server running at 'http://127.0.0.1:7829'.
Database import finished
Generating flea offers...
Started webserver at https://127.0.0.1:6969
Started websocket at wss://127.0.0.1:6969
Server has started, happy playing
```
</p>
</details> 
