### PR TITLE
v1.0.2: Linux support

### DIFF
--- a/Client/RAID-REVIEW.csproj
+++ b/Client/RAID-REVIEW.csproj
@@ -7,7 +7,7 @@
 		<AssemblyDescription>A post raid review tool for SPT</AssemblyDescription>
 		<AssemblyCompany>EkkyLLC</AssemblyCompany>
 		<AssemblyProduct>RAID_REVIEW</AssemblyProduct>
-		<AssemblyVersion>1.0.1</AssemblyVersion>
+		<AssemblyVersion>1.0.2</AssemblyVersion>
 		<Copyright>2024 © Ekky</Copyright>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<OutputPath>C:\Games\SPT-4.0\BepInEx\plugins\</OutputPath>

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -23,7 +23,7 @@ using EFT.Interactive;
 
 namespace RAID_REVIEW
 {
-    [BepInPlugin("ekky.raidreview", "Raid Review", "1.0.1")]
+    [BepInPlugin("ekky.raidreview", "Raid Review", "1.0.2")]
     [BepInDependency("me.sol.sain", BepInDependency.DependencyFlags.SoftDependency)]
     public class RAID_REVIEW : BaseUnityPlugin
     {

--- a/Private/index.html
+++ b/Private/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />

--- a/ServerMod/Database/DatabaseService.cs
+++ b/ServerMod/Database/DatabaseService.cs
@@ -9,7 +9,17 @@ public class DatabaseService : IDisposable
 
     public async Task InitializeAsync(string dataFolder)
     {
-        SQLitePCL.Batteries_V2.Init(); // Use winsqlite3.dll from Windows System32 — no native bundling needed
+        // Add the native runtimes folder to PATH so P/Invoke can find e_sqlite3.dll
+        // (SPT loads mods as plugins, so .NET won't probe the mod folder automatically)
+        var modDir = Path.GetDirectoryName(typeof(DatabaseService).Assembly.Location)!;
+        var nativeDir = Path.Combine(modDir, "runtimes", "win-x64", "native");
+        if (Directory.Exists(nativeDir))
+        {
+            var path = Environment.GetEnvironmentVariable("PATH") ?? "";
+            if (!path.Contains(nativeDir))
+                Environment.SetEnvironmentVariable("PATH", nativeDir + Path.PathSeparator + path);
+        }
+        SQLitePCL.Batteries_V2.Init();
         Directory.CreateDirectory(dataFolder);
         _dbPath = Path.Combine(dataFolder, "raid_review_mod.db");
 

--- a/ServerMod/Database/DatabaseService.cs
+++ b/ServerMod/Database/DatabaseService.cs
@@ -9,10 +9,11 @@ public class DatabaseService : IDisposable
 
     public async Task InitializeAsync(string dataFolder)
     {
-        // Add the native runtimes folder to PATH so P/Invoke can find e_sqlite3.dll
+        // Add the native runtimes folder to PATH so P/Invoke can find e_sqlite3
         // (SPT loads mods as plugins, so .NET won't probe the mod folder automatically)
         var modDir = Path.GetDirectoryName(typeof(DatabaseService).Assembly.Location)!;
-        var nativeDir = Path.Combine(modDir, "runtimes", "win-x64", "native");
+        var rid = System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier;
+        var nativeDir = Path.Combine(modDir, "runtimes", rid, "native");
         if (Directory.Exists(nativeDir))
         {
             var path = Environment.GetEnvironmentVariable("PATH") ?? "";

--- a/ServerMod/ModMetadata.cs
+++ b/ServerMod/ModMetadata.cs
@@ -4,11 +4,11 @@ namespace RaidReview;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModGuid { get; init; } = "com.ekky.raid-review";
+    public override string ModGuid { get; init; } = "ekky.raidreview";
     public override string Name { get; init; } = "Raid Review";
     public override string Author { get; init; } = "Ekky";
     public override List<string>? Contributors { get; init; } = ["Chazu"];
-    public override SemanticVersioning.Version Version { get; init; } = new("1.0.1");
+    public override SemanticVersioning.Version Version { get; init; } = new("1.0.2");
     public override SemanticVersioning.Range SptVersion { get; init; } = new("~4.0.0");
     public override List<string>? Incompatibilities { get; init; }
     public override Dictionary<string, SemanticVersioning.Range>? ModDependencies { get; init; }

--- a/ServerMod/ServerMod.csproj
+++ b/ServerMod/ServerMod.csproj
@@ -19,9 +19,9 @@
     <PackageReference Include="SPTarkov.Common" Version="4.0.5" ExcludeAssets="runtime" />
     <PackageReference Include="SPTarkov.DI" Version="4.0.5" ExcludeAssets="runtime" />
     <PackageReference Include="SPTarkov.Server.Core" Version="4.0.5" ExcludeAssets="runtime" />
-    <!-- SQLite — use winsqlite3.dll (built into Windows 10/11) to avoid native DLL path issues -->
+    <!-- SQLite — cross-platform bundle (e_sqlite3 works on Windows + Linux) -->
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.0" />
-    <PackageReference Include="SQLitePCLRaw.bundle_winsqlite3" Version="2.1.10" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" />
   </ItemGroup>
 
   <!-- Embed the React frontend INTO the DLL (avoids .js files in the mod folder,
@@ -45,6 +45,12 @@
                Exclude="$(OutputPath)SPTarkov.*;$(OutputPath)SemanticVersioning.*;$(OutputPath)JetBrains.*" />
     </ItemGroup>
     <Copy SourceFiles="@(ModDlls)" DestinationFolder="$(SptModDir)" SkipUnchangedFiles="true" />
+    <!-- Native SQLite binary — keep in runtimes subfolder so SPT doesn't try to load it as a managed assembly -->
+    <ItemGroup>
+      <NativeSqlite Include="$(OutputPath)runtimes\win-x64\native\e_sqlite3.dll" Condition="Exists('$(OutputPath)runtimes\win-x64\native\e_sqlite3.dll')" />
+    </ItemGroup>
+    <MakeDir Directories="$(SptModDir)\runtimes\win-x64\native" Condition="@(NativeSqlite) != ''" />
+    <Copy SourceFiles="@(NativeSqlite)" DestinationFolder="$(SptModDir)\runtimes\win-x64\native" SkipUnchangedFiles="true" />
     <!-- Config -->
     <Copy SourceFiles="config\config.json" DestinationFolder="$(SptModDir)\config" SkipUnchangedFiles="true" />
   </Target>

--- a/ServerMod/ServerMod.csproj
+++ b/ServerMod/ServerMod.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <OutputPath>bin\$(Configuration)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <!-- Copy NuGet runtime deps to output folder -->

--- a/publish.sh
+++ b/publish.sh
@@ -43,13 +43,25 @@ echo ">> Packaging server mod..."
 server_dest="$dist_folder/SPT/user/mods/RaidReview"
 mkdir -p "$server_dest"
 
-# Copy DLLs flat (must be next to RaidReview.dll — .NET resolves them before any mod code runs)
+# Copy managed DLLs flat (must be next to RaidReview.dll — .NET resolves them before any mod code runs)
 for f in ServerMod/bin/Release/RaidReview/*.dll; do
     base=$(basename "$f")
     case "$base" in
         SPTarkov.*|SemanticVersioning.*|JetBrains.*) continue ;;   # Already in SPT server
         *) cp "$f" "$server_dest/" ;;
     esac
+done
+
+# Copy native SQLite runtimes (win-x64 + linux-x64) into runtimes subfolder
+# Must NOT be in the mod root — SPT mod loader would try to load them as managed assemblies
+build_runtimes="ServerMod/bin/Release/RaidReview/runtimes"
+for rid in win-x64 linux-x64; do
+    native_src="$build_runtimes/$rid/native"
+    if [ -d "$native_src" ]; then
+        mkdir -p "$server_dest/runtimes/$rid/native"
+        cp "$native_src"/* "$server_dest/runtimes/$rid/native/"
+        echo "  Copied native runtime: $rid"
+    fi
 done
 
 # Copy config
@@ -76,11 +88,11 @@ done
 # 6. Create ZIP
 echo ">> Creating distribution archive..."
 cd "$dist_folder"
-powershell -Command "Compress-Archive -Force -Path '*' -DestinationPath '../${name}__${version}_windows.zip'" > /dev/null
+powershell -Command "Compress-Archive -Force -Path '*' -DestinationPath '../${name}__${version}.zip'" > /dev/null
 cd "$current_dir"
 
 # Cleanup
 rm -rf "$dist_folder"
 
 echo ""
-echo "Finished! Archive: dist/${name}__${version}_windows.zip"
+echo "Finished! Archive: dist/${name}__${version}.zip"

--- a/publish.sh
+++ b/publish.sh
@@ -3,7 +3,7 @@ set -e
 
 # Configuration
 default_name="raid_review"
-default_version="1.0.1"
+default_version="1.0.2"
 current_dir=$(pwd)
 
 echo "Let's start the deployment process..."


### PR DESCRIPTION
## Summary

- **Linux support** — switch from `winsqlite3` to cross-platform `e_sqlite3` with native runtime resolution via PATH
- **Translator DOM crash fix** — add `translate="no"` to prevent browser translators from breaking React
- **Cross-platform publish** — single zip with both win-x64 and linux-x64 native runtimes