### PR TITLE
Support secure websocket and no ports for reverse proxy

### DIFF
--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -532,8 +532,8 @@ namespace RAID_REVIEW
             BallisticsTracking = Config.Bind<bool>("Tracking Settings", "Ballistics Tracking", true, "Enables location tracking of ballistics.");
 
             // HTTP/Websocket Endpoint Builders
-            RAID_REVIEW_WS_Server = (ServerTLS.Value ? "wss://" : "ws://") + ServerAddress.Value +":" + ServerWsPort.Value;
-            RAID_REVIEW_HTTP_Server = (ServerTLS.Value ? "https://" : "http://") + ServerAddress.Value + ":" + ServerHttpPort.Value;
+            RAID_REVIEW_WS_Server = (ServerTLS.Value ? "wss://" : "ws://") + ServerAddress.Value + (ServerWsPort.Value != "" ? ":" + ServerWsPort.Value : "");
+            RAID_REVIEW_HTTP_Server = (ServerTLS.Value ? "https://" : "http://") + ServerAddress.Value + (ServerHttpPort.Value != "" ? ":" + ServerHttpPort.Value : "");
             Logger.LogInfo($"RAID_REVIEW :::: INFO :::: Configured WS Server: {RAID_REVIEW_WS_Server}");
             Logger.LogInfo($"RAID_REVIEW :::: INFO :::: Configured HTTP Server: {RAID_REVIEW_HTTP_Server}");
 

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -532,8 +532,10 @@ namespace RAID_REVIEW
             BallisticsTracking = Config.Bind<bool>("Tracking Settings", "Ballistics Tracking", true, "Enables location tracking of ballistics.");
 
             // HTTP/Websocket Endpoint Builders
-            RAID_REVIEW_WS_Server = "ws://" + ServerAddress.Value + ":" + ServerWsPort.Value;
+            RAID_REVIEW_WS_Server = (ServerTLS.Value ? "wss://" : "ws://") + ServerAddress.Value +":" + ServerWsPort.Value;
             RAID_REVIEW_HTTP_Server = (ServerTLS.Value ? "https://" : "http://") + ServerAddress.Value + ":" + ServerHttpPort.Value;
+            Logger.LogInfo($"RAID_REVIEW :::: INFO :::: Configured WS Server: {RAID_REVIEW_WS_Server}");
+            Logger.LogInfo($"RAID_REVIEW :::: INFO :::: Configured HTTP Server: {RAID_REVIEW_HTTP_Server}");
 
             Hook = new GameObject();
 


### PR DESCRIPTION
Two small changes for those using a TLS and/or a reverse proxy (like myself)
- if TLS is enabled, use secure websockets instead of regular websockets
  - if TLS is enabled it already uses https instead of http, this just matches that logic for setting up the websocket url
  - This does assume that if TLS is used for the http server then it is also used for websockets. We could split this into two different configuration parameters but I don't think it's necessary. My logic is if someone is using SSL for one, they're likely using it for both.
- if no port is specified in the `.config` then don't append the `:` to the respective address
  - I use a reverse proxy so my backend lives at https://sptarkov.DOMAIN.COM and my raid review lives at https://reivew.sptarkov.DOMAIN.COM without any ports. If I just leave the port field blank, since I don't want to specify a port, currently the `:` is still appended which causes issues.