### PR TITLE
Bump version to 1.1.1 and fix garbage collector crash on legacy DBs

### DIFF
--- a/Client/RAID-REVIEW.csproj
+++ b/Client/RAID-REVIEW.csproj
@@ -7,7 +7,7 @@
 		<AssemblyDescription>A post raid review tool for SPT</AssemblyDescription>
 		<AssemblyCompany>EkkyLLC</AssemblyCompany>
 		<AssemblyProduct>RAID_REVIEW</AssemblyProduct>
-		<AssemblyVersion>1.1.0</AssemblyVersion>
+		<AssemblyVersion>1.1.1</AssemblyVersion>
 		<Copyright>2024 © Ekky</Copyright>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<OutputPath>C:\Games\SPT-4.0-hardcore\BepInEx\plugins\</OutputPath>

--- a/ServerMod/DataIntegrity/GarbageCollector.cs
+++ b/ServerMod/DataIntegrity/GarbageCollector.cs
@@ -86,12 +86,33 @@ public class GarbageCollector
 
     private async Task DeleteRaidDataAsync(string raidId)
     {
-        // Delete child tables first, then raid (parent) last — foreign keys enforce this order
-        foreach (var table in new[] { "kills", "looting", "player", "player_status", "ballistic", "loose_loot", "player_inventory", "bot_quest", "bot_objective", "phobos_field", "orbit_field", "orbit_bot_objective", "orbit_main_objectives", "raid" })
+        var tables = new[] { "kills", "looting", "player", "player_status", "ballistic", "loose_loot", "player_inventory", "bot_quest", "bot_objective", "phobos_field", "orbit_field", "orbit_bot_objective", "orbit_main_objectives", "raid" };
+
+        // FK enforcement off during GC: legacy DBs can carry orphan rows
+        // in tables that were dropped/renamed across past migrations, and
+        // those would block delete on commit otherwise. PRAGMA foreign_keys
+        // is a connection-level toggle and is a no-op inside a transaction.
+        await _db.ExecuteAsync("PRAGMA foreign_keys = OFF");
+        try
         {
-            await _db.ExecuteAsync($"DELETE FROM {table} WHERE raidId = $raidId",
-                ("$raidId", raidId));
+            foreach (var table in tables)
+            {
+                try
+                {
+                    await _db.ExecuteAsync($"DELETE FROM {table} WHERE raidId = $raidId",
+                        ("$raidId", raidId));
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn($"Failed to clean {table} for raid {raidId}: {ex.Message}");
+                }
+            }
         }
+        finally
+        {
+            await _db.ExecuteAsync("PRAGMA foreign_keys = ON");
+        }
+
         _fileService.DeleteFile("positions", "", "", $"{raidId}_positions");
         _fileService.DeleteFile("positions", "", "", $"{raidId}_{ActiveVersion}_positions.json");
     }

--- a/ServerMod/ServerMod.csproj
+++ b/ServerMod/ServerMod.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <OutputPath>bin\$(Configuration)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <!-- Copy NuGet runtime deps to output folder -->


### PR DESCRIPTION
## 🐛 Fixes

- Garbage collector no longer crashes the server on startup when a legacy DB carries orphan rows from older migrations. Foreign-key enforcement is now disabled for the GC pass and each table cleanup is wrapped in its own try/catch so one bad row can't take down the whole purge.