### PR TITLE
Raid Review 1.2.0

### DIFF
--- a/Client/RAID-REVIEW.csproj
+++ b/Client/RAID-REVIEW.csproj
@@ -7,7 +7,7 @@
 		<AssemblyDescription>A post raid review tool for SPT</AssemblyDescription>
 		<AssemblyCompany>EkkyLLC</AssemblyCompany>
 		<AssemblyProduct>RAID_REVIEW</AssemblyProduct>
-		<AssemblyVersion>1.1.1</AssemblyVersion>
+		<AssemblyVersion>1.2.0</AssemblyVersion>
 		<Copyright>2024 © Ekky</Copyright>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<OutputPath>C:\Games\SPT-4.0-hardcore\BepInEx\plugins\</OutputPath>

--- a/Client/integrations/Integrations.cs
+++ b/Client/integrations/Integrations.cs
@@ -77,6 +77,14 @@ namespace RAID_REVIEW {
                     LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: Found 'Black Division'.");
                     RAID_REVIEW.RAID_REVIEW__DETECTED_MODS.Add("BLACK_DIVISION");
                 }
+                // ISB SOF ships several plugins (ISBSpecialForces / ISBNotify / ISBSOF_Extras)
+                // whose GUIDs vary by version and com.-prefix, so match any loaded plugin
+                // whose GUID contains "isb" rather than guessing one exact id.
+                if (RAID_REVIEW.DetectModContaining("isb"))
+                {
+                    LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: Found 'ISB SOF'.");
+                    RAID_REVIEW.RAID_REVIEW__DETECTED_MODS.Add("ISB");
+                }
                 LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: Finished Searching For Supported Mods");
             }
             LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: RAID Settings Loaded");

--- a/Client/integrations/Orbit.cs
+++ b/Client/integrations/Orbit.cs
@@ -15,13 +15,26 @@ namespace RAID_REVIEW
     /// </summary>
     class Orbit_Integration
     {
+        private static bool _apiReadyLogged;
+
         /// <summary>Kept for API symmetry with the legacy Phobos_Integration.
         /// The new API doesn't need any per-raid reflection bootstrap, so
-        /// this is just a probe log.</summary>
+        /// this is just a one-shot probe log per raid (caller invokes this
+        /// every tick — without the latch we'd flood the log with thousands
+        /// of identical "API ready" lines).</summary>
         public static void InitReflection()
         {
-            if (OrbitTelemetry.IsAvailable)
-                LoggerInstance.Log.LogInfo("RAID_REVIEW :::: ORBIT :::: API ready");
+            if (_apiReadyLogged) return;
+            if (!OrbitTelemetry.IsAvailable) return;
+            LoggerInstance.Log.LogInfo("RAID_REVIEW :::: ORBIT :::: API ready");
+            _apiReadyLogged = true;
+        }
+
+        /// <summary>Reset the one-shot init log when a new raid starts.
+        /// Called from mod.cs's raid-start hook.</summary>
+        public static void ResetSessionState()
+        {
+            _apiReadyLogged = false;
         }
 
         /// <summary>No-op in the API-based integration — the API resolves

--- a/Client/integrations/SAIN.cs
+++ b/Client/integrations/SAIN.cs
@@ -131,11 +131,20 @@ namespace RAID_REVIEW
                                     {
                                         trackingPlayer.type = sainType;
                                     }
+
+                                    // ISB faction only: capture SAIN's bot-type display name
+                                    // (e.g. "ISB Operator") from SAIN's static registry, keyed by
+                                    // WildSpawnType. This is the name the faction author controls,
+                                    // so it isn't tied to the (often misleading) WildSpawnType role.
+                                    if (sainType.EndsWith("|ISB"))
+                                    {
+                                        trackingPlayer.mod_SAIN_name = getSainBotTypeName(profile);
+                                    }
                                 }
 
                                 RAID_REVIEW.trackingPlayers[trackingPlayer.profileId] = trackingPlayer;
                                 RAID_REVIEW.updatedBots[trackingPlayer.profileId] = trackingPlayer;
-                                LoggerInstance.Log.LogInfo($"RAID_REVIEW :::: INFO :::: Updating player {trackingPlayer.name} with brain {trackingPlayer.mod_SAIN_brain}, type {trackingPlayer.type}, difficulty {trackingPlayer.mod_SAIN_difficulty}");
+                                LoggerInstance.Log.LogInfo($"RAID_REVIEW :::: INFO :::: Updating player {trackingPlayer.name} with brain {trackingPlayer.mod_SAIN_brain}, type {trackingPlayer.type}, difficulty {trackingPlayer.mod_SAIN_difficulty}, sainName {trackingPlayer.mod_SAIN_name}");
                                 _ = Telemetry.Send("PLAYER_UPDATE", JsonConvert.SerializeObject(trackingPlayer));
                             }
                         }
@@ -460,6 +469,37 @@ namespace RAID_REVIEW
             }
 
             return RR_WildSpawnType;
+        }
+
+        // Reads SAIN's per-WildSpawnType display name (e.g. "ISB Operator") from SAIN's
+        // static BotTypeDefinitions registry. MoreBotsAPI copies a faction mod's custom
+        // SAIN settings into SAIN's native BotType (keyed by WildSpawnType), so this is the
+        // author-controlled name shown in SAIN's settings menu. Returns "" when SAIN isn't
+        // present or the type isn't registered (we use ContainsKey, never GetBotType, to
+        // avoid SAIN's "assault"/Scav fallback).
+        public static string getSainBotTypeName(object profile)
+        {
+            try
+            {
+                if (profile == null) return "";
+
+                var wildSpawnType = profile.GetType().GetProperty("WildSpawnType")?.GetValue(profile)
+                                 ?? profile.GetType().GetField("WildSpawnType")?.GetValue(profile);
+                if (wildSpawnType == null) return "";
+
+                Type botTypeDefsType = Type.GetType("SAIN.Preset.BotTypeDefinitions, SAIN");
+                var botTypes = botTypeDefsType?.GetField("BotTypes", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) as IDictionary;
+                if (botTypes == null || !botTypes.Contains(wildSpawnType)) return "";
+
+                var botType = botTypes[wildSpawnType];
+                var name = botType?.GetType().GetField("Name", BindingFlags.Public | BindingFlags.Instance)?.GetValue(botType) as string;
+                return name ?? "";
+            }
+            catch (Exception e)
+            {
+                LoggerInstance.Log?.LogError($"RAID_REVIEW :::: ERROR :::: getSainBotTypeName: {e}");
+                return "";
+            }
         }
 
 

--- a/Client/integrations/SAIN.cs
+++ b/Client/integrations/SAIN.cs
@@ -413,6 +413,32 @@ namespace RAID_REVIEW
                             RR_WildSpawnType = "BLACK DIV SUPPORT|BLACKDIV";
                             break;
 
+                        // ISB faction mod (mirror of MapWildSpawnType in mod.cs)
+                        case "ISBSpecialForces":
+                            RR_WildSpawnType = "ISB SPECIAL FORCES|ISB";
+                            break;
+                        case "ISBTeamLeader":
+                            RR_WildSpawnType = "ISB TEAM LEADER|ISB";
+                            break;
+                        case "ISBSecondLeader":
+                            RR_WildSpawnType = "ISB SECOND LEADER|ISB";
+                            break;
+                        case "ISBFirefly":
+                            RR_WildSpawnType = "ISB FIREFLY|ISB";
+                            break;
+                        case "ISBFireflyFollowerLoghan":
+                            RR_WildSpawnType = "ISB FIREFLY LOGHAN|ISB";
+                            break;
+                        case "ISBFireflyFollowerVipper":
+                            RR_WildSpawnType = "ISB FIREFLY VIPPER|ISB";
+                            break;
+                        case "ISBFireflyShielder01":
+                            RR_WildSpawnType = "ISB FIREFLY SHIELDER 1|ISB";
+                            break;
+                        case "ISBFireflyShielder02":
+                            RR_WildSpawnType = "ISB FIREFLY SHIELDER 2|ISB";
+                            break;
+
                         default:
                             // Graceful fallback for unknown custom faction mods
                             RR_WildSpawnType = wildSpawnType.ToString().ToUpper() + "|FACTION_MOD";

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -708,6 +708,7 @@ namespace RAID_REVIEW
                                 _seenLayerNames.Clear();
                                 sessionId = null;
                                 stopwatch.Reset();
+                                if (ORBIT__DETECTED) Orbit_Integration.ResetSessionState();
                             }
                         }
                         continue;

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -156,6 +156,17 @@ namespace RAID_REVIEW
                 case "blackDivAssault": return "BLACK DIV ASSAULT|BLACKDIV";
                 case "blackDivBreacher": return "BLACK DIV BREACHER|BLACKDIV";
                 case "blackDivSupport": return "BLACK DIV SUPPORT|BLACKDIV";
+                // ISB faction mod. Custom WildSpawnType member names (role.ToString() yields the
+                // member name for these, same as the other faction mods above). Future Firefly squad
+                // members are mapped ahead of the mod shipping them.
+                case "ISBSpecialForces": return "ISB SPECIAL FORCES|ISB";
+                case "ISBTeamLeader": return "ISB TEAM LEADER|ISB";
+                case "ISBSecondLeader": return "ISB SECOND LEADER|ISB";
+                case "ISBFirefly": return "ISB FIREFLY|ISB";
+                case "ISBFireflyFollowerLoghan": return "ISB FIREFLY LOGHAN|ISB";
+                case "ISBFireflyFollowerVipper": return "ISB FIREFLY VIPPER|ISB";
+                case "ISBFireflyShielder01": return "ISB FIREFLY SHIELDER 1|ISB";
+                case "ISBFireflyShielder02": return "ISB FIREFLY SHIELDER 2|ISB";
                 default: return role.ToString().ToUpper() + "|FACTION_MOD";
             }
         }

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -1099,6 +1099,15 @@ namespace RAID_REVIEW
             if (Chainloader.PluginInfos.ContainsKey(modName)) return true;
             return false;
         }
+        // ISB SOF ships several plugins (ISBSpecialForces / ISBNotify / ISBSOF_Extras)
+        // whose GUIDs vary by version and com.-prefix, so match any loaded plugin whose
+        // GUID contains the substring instead of relying on one exact id.
+        public static bool DetectModContaining(string substring)
+        {
+            foreach (var key in Chainloader.PluginInfos.Keys)
+                if (key.IndexOf(substring, System.StringComparison.OrdinalIgnoreCase) >= 0) return true;
+            return false;
+        }
         public static bool MapLoaded() => Singleton<GameWorld>.Instantiated;
 
     }

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -799,7 +799,8 @@ namespace RAID_REVIEW
                                 spawnTime = stopwatch.ElapsedMilliseconds,
                                 type = player.IsAI ? "BOT" : "HUMAN",
                                 mod_SAIN_brain = "UNKNOWN",
-                                mod_SAIN_difficulty = ""
+                                mod_SAIN_difficulty = "",
+                                mod_SAIN_name = ""
                             };
 
                             if (player.Side == EPlayerSide.Savage)

--- a/Client/models/Tracking.cs
+++ b/Client/models/Tracking.cs
@@ -34,6 +34,7 @@ namespace RAID_REVIEW
         public long spawnTime { get; set; }
         public string mod_SAIN_brain { get; set; }
         public string mod_SAIN_difficulty { get; set; }
+        public string mod_SAIN_name { get; set; }
     }
 
     public class TrackingRaidKill

--- a/Private/src/assets/botMapping.json
+++ b/Private/src/assets/botMapping.json
@@ -259,6 +259,38 @@
         "name": "Black Div Support",
         "type": "BLACKDIV"
     },
+    "ISB SPECIAL FORCES|ISB": {
+        "name": "ISB Special Forces",
+        "type": "ISB"
+    },
+    "ISB TEAM LEADER|ISB": {
+        "name": "ISB Team Leader",
+        "type": "ISB"
+    },
+    "ISB SECOND LEADER|ISB": {
+        "name": "ISB Second Leader",
+        "type": "ISB"
+    },
+    "ISB FIREFLY|ISB": {
+        "name": "ISB Firefly",
+        "type": "ISB"
+    },
+    "ISB FIREFLY LOGHAN|ISB": {
+        "name": "ISB Firefly Loghan",
+        "type": "ISB"
+    },
+    "ISB FIREFLY VIPPER|ISB": {
+        "name": "ISB Firefly Vipper",
+        "type": "ISB"
+    },
+    "ISB FIREFLY SHIELDER 1|ISB": {
+        "name": "ISB Firefly Shielder 1",
+        "type": "ISB"
+    },
+    "ISB FIREFLY SHIELDER 2|ISB": {
+        "name": "ISB Firefly Shielder 2",
+        "type": "ISB"
+    },
     "UNKNOWN": {
         "name": "",
         "type": ""

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -134,9 +134,11 @@ function resolveQuestName(triggerName: string, map: Record<string, string>): str
     return best
 }
 
-function createPlayerMarker(latlng: any, color: string, player: any, proportionalScale: number, opacity: number = 1, pmcIndex?: number, tooltipText?: string, behaviorColor?: string | null, hpPercent?: number): L.Layer {
-    const displayName = tooltipText || getDisplayName(player)
-    const tooltipOpts: L.TooltipOptions = { direction: 'top', offset: [0, -10], className: 'player-tooltip' }
+// Builds the divIcon for a player dot plus the raw html string used for it, so
+// callers can cheaply detect when the icon actually changed between frames and
+// avoid a needless setIcon (which swaps the DOM element and disrupts an open
+// tooltip — see issue #24).
+function buildPlayerIcon(color: string, player: any, proportionalScale: number, opacity: number, pmcIndex?: number, behaviorColor?: string | null, hpPercent?: number): { icon: L.DivIcon, html: string } {
     const ringStyle = behaviorColor ? `box-shadow: 0 0 0 3px ${behaviorColor}, 0 0 6px 1px ${behaviorColor}55;` : ''
     // HP fill: gradient from bottom (color) to top (dark) based on HP percentage
     const hp = hpPercent != null ? Math.max(0, Math.min(100, hpPercent)) : 100
@@ -146,42 +148,55 @@ function createPlayerMarker(latlng: any, color: string, player: any, proportiona
     const label = getMarkerLabel(player)
     if (label === 'BTR_ICON') {
         const btrSvg = `<svg viewBox="0 0 24 18" width="24" height="18" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="2" y="3" width="20" height="8" rx="1" fill="${color}" opacity="${opacity}"/><rect x="5" y="1" width="10" height="4" rx="1" fill="${color}" opacity="${opacity}"/><line x1="15" y1="3" x2="20" y2="5" stroke="${color}" stroke-width="1.2" opacity="${opacity}"/><circle cx="5.5" cy="13.5" r="2.5" fill="${color}" opacity="${opacity}"/><circle cx="12" cy="13.5" r="2.5" fill="${color}" opacity="${opacity}"/><circle cx="18.5" cy="13.5" r="2.5" fill="${color}" opacity="${opacity}"/><circle cx="5.5" cy="13.5" r="1" fill="#1a1a1a"/><circle cx="12" cy="13.5" r="1" fill="#1a1a1a"/><circle cx="18.5" cy="13.5" r="1" fill="#1a1a1a"/></svg>`
-        const icon = L.divIcon({
-            className: 'special-bot-marker',
-            html: `<div style="display:flex;align-items:center;justify-content:center;filter:drop-shadow(0 0 2px rgba(0,0,0,0.9));${ringStyle}">${btrSvg}</div>`,
-            iconSize: [24, 20],
-            iconAnchor: [12, 10],
-        })
-        return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, { ...tooltipOpts, className: 'player-tooltip player-tooltip-html' })
+        const html = `<div style="display:flex;align-items:center;justify-content:center;filter:drop-shadow(0 0 2px rgba(0,0,0,0.9));${ringStyle}">${btrSvg}</div>`
+        return { icon: L.divIcon({ className: 'special-bot-marker', html, iconSize: [24, 20], iconAnchor: [12, 10] }), html }
     }
     if (label) {
-        const icon = L.divIcon({
-            className: 'special-bot-marker',
-            html: `<div class="bot-marker-dot" style="${bgStyle} opacity: ${opacity}; ${ringStyle}">${label}</div>`,
-            iconSize: [18, 18],
-            iconAnchor: [9, 9],
-        })
-        return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, { ...tooltipOpts, className: 'player-tooltip player-tooltip-html' })
+        const html = `<div class="bot-marker-dot" style="${bgStyle} opacity: ${opacity}; ${ringStyle}">${label}</div>`
+        return { icon: L.divIcon({ className: 'special-bot-marker', html, iconSize: [18, 18], iconAnchor: [9, 9] }), html }
     }
     // PMCs and player scavs get white border + number label
     if (pmcIndex !== undefined) {
-        const icon = L.divIcon({
-            className: 'special-bot-marker',
-            html: `<div class="bot-marker-dot bot-marker-round" style="${bgStyle} opacity: ${opacity}; ${ringStyle}">${pmcIndex}</div>`,
-            iconSize: [18, 18],
-            iconAnchor: [9, 9],
-        })
-        return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, { ...tooltipOpts, className: 'player-tooltip player-tooltip-html' })
+        const html = `<div class="bot-marker-dot bot-marker-round" style="${bgStyle} opacity: ${opacity}; ${ringStyle}">${pmcIndex}</div>`
+        return { icon: L.divIcon({ className: 'special-bot-marker', html, iconSize: [18, 18], iconAnchor: [9, 9] }), html }
     }
     // Scavs: plain circle — always use divIcon for HP fill + behavior ring support
     const size = Math.max(10, proportionalScale * 2)
-    const icon = L.divIcon({
-        className: 'special-bot-marker',
-        html: `<div style="width:${size}px;height:${size}px;border-radius:50%;${bgStyle}opacity:${opacity};${ringStyle}"></div>`,
-        iconSize: [size, size],
-        iconAnchor: [size / 2, size / 2],
-    })
-    return L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, { ...tooltipOpts, className: 'player-tooltip player-tooltip-html' })
+    const html = `<div style="width:${size}px;height:${size}px;border-radius:50%;${bgStyle}opacity:${opacity};${ringStyle}"></div>`
+    return { icon: L.divIcon({ className: 'special-bot-marker', html, iconSize: [size, size], iconAnchor: [size / 2, size / 2] }), html }
+}
+
+function createPlayerMarker(latlng: any, color: string, player: any, proportionalScale: number, opacity: number = 1, pmcIndex?: number, tooltipText?: string, behaviorColor?: string | null, hpPercent?: number): L.Marker {
+    const displayName = tooltipText || getDisplayName(player)
+    const tooltipOpts: L.TooltipOptions = { direction: 'top', offset: [0, -10], className: 'player-tooltip player-tooltip-html' }
+    const { icon, html } = buildPlayerIcon(color, player, proportionalScale, opacity, pmcIndex, behaviorColor, hpPercent)
+    const marker = L.marker(latlng, { icon, interactive: true }).bindTooltip(displayName, tooltipOpts) as L.Marker
+    ;(marker as any)._rr_iconHtml = html
+    ;(marker as any)._rr_baseTooltip = displayName
+    return marker
+}
+
+// Mutates an existing persistent player marker in place rather than tearing it
+// down + rebuilding it every playback frame (issue #24). Preserves the Leaflet
+// layer + tooltip identity so the hovered/followed tooltip never flickers.
+function updatePlayerMarker(marker: L.Marker, latlng: any, color: string, player: any, proportionalScale: number, opacity: number, pmcIndex: number | undefined, tooltipText: string, behaviorColor: string | null | undefined, hpPercent: number | undefined, isFocused: boolean): void {
+    marker.setLatLng(latlng)
+    const { icon, html } = buildPlayerIcon(color, player, proportionalScale, opacity, pmcIndex, behaviorColor, hpPercent)
+    // Only swap the icon element when the visuals actually changed, and never
+    // while this is the focused/hovered marker — setIcon recreates the DOM node
+    // and would interrupt the open tooltip.
+    if (html !== (marker as any)._rr_iconHtml && !isFocused) {
+        marker.setIcon(icon)
+        ;(marker as any)._rr_iconHtml = html
+    }
+    const displayName = tooltipText || getDisplayName(player)
+    // Stash the latest base text so the focus overlay can enrich from it; only
+    // write the live tooltip for non-focused markers (the focus overlay owns the
+    // focused one and avoids per-frame open/close churn).
+    ;(marker as any)._rr_baseTooltip = displayName
+    if (!isFocused) {
+        marker.setTooltipContent(displayName)
+    }
 }
 import '../modules/leaflet-heat.js'
 import './Map.css'
@@ -485,6 +500,16 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
     const focusVictimIdsRef = useRef<Set<string>>(new Set())
     const focusKillerIdRef = useRef<string | null>(null)
     const focusLayersRef = useRef<L.Layer[]>([])
+    // Persistent player-dot markers keyed by playerId, mutated in place across
+    // playback frames instead of being torn down + rebuilt every tick. Fixes the
+    // tooltip flicker + name jitter reported in issue #24.
+    const playerMarkersRef = useRef<Map<string, L.Marker>>(new Map())
+    // The focus-overlay tooltip currently applied {id, html}, so we only re-issue
+    // setTooltipContent/openTooltip when it actually changes (no per-frame churn).
+    const focusTooltipRef = useRef<{ id: string, html: string } | null>(null)
+    // Signature of the focus kill-visualization (focus + kill-set) so the skull
+    // markers / kill lines are only rebuilt on real changes, not every frame.
+    const killVizSigRef = useRef<string | null>(null)
     const mapViewRef = useRef({})
 
     // Kill relationship sets for legend highlighting + refs for position renderer
@@ -821,8 +846,12 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
 
         clearMap(MAP, { start: timeStartLimit, end: timeEndLimit })
 
-        // Two-pass rendering: polylines first, then markers (so dots are always on top)
-        const deferredMarkers: { layer: L.Layer, playerId: string, followAction?: boolean }[] = []
+        // Issue #24: player markers are persistent and mutated in place (see
+        // playerMarkersRef); track which players we render this frame so we can
+        // cull markers for players who died or scrubbed out of the time window.
+        // Dots live in Leaflet's markerPane, which sits above the overlayPane the
+        // per-frame polylines are re-added to, so they always stay on top.
+        const renderedPlayerIds = new Set<string>()
 
         const playerPositionKeys = Object.keys(positions)
         for (let i = 0; i < playerPositionKeys.length; i++) {
@@ -973,47 +1002,62 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                     const tip = `${getDisplayName(player)} (${getPlayerDifficultyAndBrain(player)})${healthLine}${behaviorLine}${extractLine}${lootLine}`
                     const ringColor = behaviorCat && behaviorCat.key !== 'idle' && behaviorCat.key !== 'patrol' ? behaviorCat.color : undefined
                     const hpPct = (currentHealth != null && maxHealth != null && maxHealth > 0) ? Math.round((currentHealth / maxHealth) * 100) : undefined
-                    const marker = createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, markerOpacity, pmcIndexMap[playerId], tip, ringColor, hpPct)
-                    marker._rr_playerId = playerId
-                    marker._rr_isDead = false
-                    marker._rr_normalOpacity = 1
-                    deferredMarkers.push({ layer: marker, playerId })
+                    const isFocused = playerFocusRef.current === playerId
+                    let marker = playerMarkersRef.current.get(playerId)
+                    if (!marker) {
+                        // First appearance: create once, wire listeners once.
+                        marker = createPlayerMarker(endOfLine, pickedColor, player, proportionalScale, markerOpacity, pmcIndexMap[playerId], tip, ringColor, hpPct)
+                        marker._rr_playerId = playerId
+                        marker._rr_isDead = false
+                        marker._rr_normalOpacity = 1
+                        marker._rr_persistentPlayer = true
+                        marker.addTo(MAP)
+                        marker.on('mouseover', () => {
+                            if (focusTimeoutRef.current) clearTimeout(focusTimeoutRef.current)
+                            setPlayerFocus(playerId)
+                        })
+                        marker.on('mouseout', () => {
+                            if (focusTimeoutRef.current) clearTimeout(focusTimeoutRef.current)
+                            focusTimeoutRef.current = setTimeout(() => setPlayerFocus(null), 100)
+                        })
+                        // ORBIT main objectives: click any bot marker to toggle
+                        // the per-squad mains overlay (see findSquadIdForPlayer).
+                        marker.on('click', () => {
+                            const sqId = findSquadIdForPlayer(playerId)
+                            if (sqId == null) return
+                            setSelectedSquadForMains(prev => prev === sqId ? null : sqId)
+                        })
+                        playerMarkersRef.current.set(playerId, marker)
+                    } else {
+                        // Subsequent frames: mutate in place — no teardown/rebind.
+                        updatePlayerMarker(marker, endOfLine, pickedColor, player, proportionalScale, markerOpacity, pmcIndexMap[playerId], tip, ringColor, hpPct, isFocused)
+                        marker._rr_isDead = false
+                        marker._rr_normalOpacity = 1
+                    }
+                    renderedPlayerIds.add(playerId)
                     if (followPlayer === playerId) {
                         if (!followPlayerZoomed) {
                             MAP.setZoom(3)
                             setFollowPlayerZoomed(true)
                         }
-                        MAP.panTo(endOfLine, 4)
+                        // Snap (no pan animation): the bare `4` here used to take
+                        // Leaflet's animated branch, restarting a 0.25s tween every
+                        // frame and producing the ~1px name jitter from issue #24.
+                        MAP.panTo(endOfLine, { animate: false })
                     }
                 }
             }
         }
 
-        // Second pass: add all markers on top of polylines
-        for (const { layer, playerId } of deferredMarkers) {
-            layer.addTo(MAP)
-            layer.on('mouseover', () => {
-                if (focusTimeoutRef.current) clearTimeout(focusTimeoutRef.current)
-                setPlayerFocus(playerId)
-            })
-            layer.on('mouseout', () => {
-                if (focusTimeoutRef.current) clearTimeout(focusTimeoutRef.current)
-                focusTimeoutRef.current = setTimeout(() => setPlayerFocus(null), 100)
-            })
-            // ORBIT main objectives: click any bot marker to toggle
-            // the per-squad mains overlay. If THAT squad is already
-            // selected, click hides it. If a different squad's mains
-            // are showing, the click swaps to the new squad. If no
-            // squad's mains data exists for this bot (bot scav / boss
-            // / raider — they skip the system), the click is a no-op.
-            layer.on('click', () => {
-                // Scan all snapshots (not just ≤ timeEndLimit) so a dead
-                // bot's dot still resolves to its historic squad. See
-                // findSquadIdForPlayer for the why.
-                const sqId = findSquadIdForPlayer(playerId)
-                if (sqId == null) return
-                setSelectedSquadForMains(prev => prev === sqId ? null : sqId)
-            })
+        // Cull persistent markers for players not rendered this frame — i.e. the
+        // player died (isPlayerDead), was hidden (hidePlayers), or scrubbed out of
+        // the time window (empty cleanPositions). The old stateless rebuild got
+        // this for free via clearMap; persistent markers must reconcile it here.
+        for (const [pid, marker] of playerMarkersRef.current) {
+            if (!renderedPlayerIds.has(pid)) {
+                try { marker.remove() } catch (e) { /* layer/map already gone */ }
+                playerMarkersRef.current.delete(pid)
+            }
         }
 
         if (sliderTimes.length === 0) {
@@ -1033,11 +1077,24 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
         if (!MAP || !mapIsReady) return
         playerFocusRef.current = playerFocus
 
-        // Clean up previous focus layers
-        for (const layer of focusLayersRef.current) {
-            MAP.removeLayer(layer)
+        // Issue #24 follow-up: the kill-visualization layers (kill/death lines,
+        // skull markers, dead-player temp marker) are static for a given focus +
+        // kill-set, but this effect re-runs every playback frame (timeEndLimit is a
+        // dep, needed to keep the focused tooltip's live HP/loot fresh). Only tear
+        // them down + rebuild when the focus or relevant kill-set actually changes,
+        // otherwise the skull icons strobe while hovering the killer during play.
+        const killVizSig = playerFocus
+            ? `${playerFocus}|${events.filter(e => (e.killedId === playerFocus || (e.profileId === playerFocus && e.profileId !== e.killedId)) && e.time < timeEndLimit).length}`
+            : ''
+        const killVizChanged = killVizSig !== killVizSigRef.current
+        if (killVizChanged) {
+            killVizSigRef.current = killVizSig
+            // Clean up previous focus layers
+            for (const layer of focusLayersRef.current) {
+                MAP.removeLayer(layer)
+            }
+            focusLayersRef.current = []
         }
-        focusLayersRef.current = []
 
         // Build victim/killer sets for kill relationship highlighting
         const victimIds = new Set<string>()
@@ -1096,14 +1153,17 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
             }
         }
 
-        // Restore any previously modified tooltips, then enrich focused player's dot tooltip
-        for (const key in MAP._layers) {
-            const layer = MAP._layers[key]
-            if (layer._rr_originalTooltip !== undefined) {
-                layer.setTooltipContent(layer._rr_originalTooltip)
-                layer.closeTooltip()
-                delete layer._rr_originalTooltip
+        // Issue #24: this effect re-runs every playback frame (timeEndLimit is a
+        // dep), so we must NOT blindly close/reopen the focused tooltip each tick.
+        // When focus moves off a marker, revert it to its base tooltip once.
+        const prevFocus = focusTooltipRef.current
+        if (prevFocus && prevFocus.id !== playerFocus) {
+            const prevMarker = playerMarkersRef.current.get(prevFocus.id)
+            if (prevMarker) {
+                if (prevMarker._rr_baseTooltip !== undefined) prevMarker.setTooltipContent(prevMarker._rr_baseTooltip)
+                prevMarker.closeTooltip()
             }
+            focusTooltipRef.current = null
         }
         if (playerFocus) {
             const kills = events.filter(e => e.profileId === playerFocus && e.profileId !== e.killedId && e.time < timeEndLimit)
@@ -1131,24 +1191,26 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                 return html
             }
 
-            // Try to find existing marker for this player (alive players)
-            let found = false
-            for (const key in MAP._layers) {
-                const layer = MAP._layers[key]
-                if (layer._rr_playerId === playerFocus && (layer instanceof L.Marker || layer instanceof L.Circle)) {
-                    const tooltip = layer.getTooltip()
-                    if (tooltip) {
-                        layer._rr_originalTooltip = tooltip.getContent()
-                        layer.setTooltipContent(buildFeedHtml(layer._rr_originalTooltip))
-                        layer.openTooltip()
-                    }
-                    found = true
-                    break
+            // Alive player: enrich the persistent marker's tooltip in place. Only
+            // (re)apply when the content actually changed, and call openTooltip at
+            // most once — this is what removes the per-frame flicker (issue #24).
+            const marker = playerMarkersRef.current.get(playerFocus)
+            if (marker) {
+                const base = marker._rr_baseTooltip !== undefined
+                    ? marker._rr_baseTooltip
+                    : (marker.getTooltip()?.getContent() ?? '')
+                const html = buildFeedHtml(base as string)
+                const prev = focusTooltipRef.current
+                if (!prev || prev.id !== playerFocus || prev.html !== html) {
+                    marker.setTooltipContent(html)
+                    if (!(marker.isTooltipOpen && marker.isTooltipOpen())) marker.openTooltip()
+                    focusTooltipRef.current = { id: playerFocus, html }
                 }
             }
 
             // Dead player: no marker on map, create a temporary one at death position
-            if (!found && death) {
+            // (gated: only (re)build when the kill-set/focus changed — see killVizSig)
+            if (killVizChanged && !marker && death) {
                 const player = raidData.players.find(p => p.profileId === playerFocus)
                 const playerIdx = player ? raidData.players.indexOf(player) : 0
                 const color = player ? getPlayerColor(player, playerIdx) : '#999'
@@ -1158,12 +1220,14 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                 }).addTo(MAP)
                 tmpMarker.bindTooltip(buildFeedHtml(displayName), { direction: 'top', offset: [0, -10], className: 'player-tooltip' })
                 tmpMarker.openTooltip()
+                tmpMarker._rr_focusViz = true
                 focusLayersRef.current.push(tmpMarker)
             }
         }
 
-        // Add kill visualization if a player is focused
-        if (playerFocus && events.length > 0) {
+        // Add kill visualization if a player is focused (gated by killVizSig so the
+        // skull markers / lines are not torn down + rebuilt every playback frame).
+        if (killVizChanged && playerFocus && events.length > 0) {
             // Kills made by hovered player (respecting timeline)
             const playerKills = events.filter(e => e.profileId === playerFocus && e.profileId !== e.killedId && e.time < timeEndLimit)
             for (const kill of playerKills) {
@@ -1171,10 +1235,12 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                     [[kill.source.z, kill.source.x], [kill.target.z, kill.target.x]],
                     { color: 'red', weight: 2, dashArray: [10], dashOffset: 3, opacity: 1, interactive: false }
                 ).addTo(MAP)
+                line._rr_focusViz = true
                 focusLayersRef.current.push(line)
                 const skullHtml = `<img src="/skull.png" /><span class="tooltiptext event event-map text-sm"><strong>${kill.killedNickname}</strong><br/>${intl([kill.weapon.replace('Name', 'ShortName')], intl_dir)}, ${kill.distance.toFixed(0)}m${kill.bodyPart ? ', ' + kill.bodyPart : ''}</span>`
                 const skullIcon = L.divIcon({ className: 'death-icon tooltip event follow-kill-marker', html: skullHtml })
                 const marker = L.marker([kill.target.z, kill.target.x], { icon: skullIcon, interactive: false, zIndexOffset: -1000 }).addTo(MAP)
+                marker._rr_focusViz = true
                 focusLayersRef.current.push(marker)
             }
 
@@ -1185,14 +1251,31 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                     [[deathEvent.source.z, deathEvent.source.x], [deathEvent.target.z, deathEvent.target.x]],
                     { color: 'red', weight: 2, dashArray: [10], dashOffset: 3, opacity: 1, interactive: false }
                 ).addTo(MAP)
+                line._rr_focusViz = true
                 focusLayersRef.current.push(line)
                 const ownDeathHtml = `<div class="own-death-ring"><img src="/skull.png" /></div><span class="tooltiptext event event-map text-sm"><strong>${deathEvent.profileNickname}</strong><br/>killed<br/><strong>${deathEvent.killedNickname}</strong><br/>${intl([deathEvent.weapon.replace('Name', 'ShortName')], intl_dir)}, ${deathEvent.distance.toFixed(0)}m${deathEvent.bodyPart ? ', ' + deathEvent.bodyPart : ''}</span>`
                 const ownDeathIcon = L.divIcon({ className: 'death-icon tooltip event follow-kill-marker', html: ownDeathHtml })
                 const marker = L.marker([deathEvent.target.z, deathEvent.target.x], { icon: ownDeathIcon, interactive: false, zIndexOffset: -1000 }).addTo(MAP)
+                marker._rr_focusViz = true
                 focusLayersRef.current.push(marker)
             }
         }
     }, [playerFocus, MAP, mapIsReady, events, timeEndLimit, intl_dir])
+
+    // Issue #24: persistent player markers live across frames; when the map
+    // instance is torn down/rebuilt, drop them so the ref never holds dead layers.
+    useEffect(() => {
+        return () => {
+            playerMarkersRef.current.forEach((marker) => {
+                try { marker.remove() } catch (e) { /* map already gone */ }
+            })
+            playerMarkersRef.current.clear()
+            focusTooltipRef.current = null
+            // Force the gated focus kill-viz to rebuild on the next (new) map.
+            killVizSigRef.current = null
+            focusLayersRef.current = []
+        }
+    }, [MAP])
 
     // Slider Time Update
     useEffect(() => {
@@ -1550,6 +1633,53 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
         return ids
     }, [raidData?.looting, timeEndLimit])
 
+    // Discrete timeline-progress signals (issue #24 follow-up). The overlay
+    // effects below are timeline-aware but their rendered marker/tooltip set only
+    // changes when an event crosses the playhead, not on every animation frame.
+    // Keying those effects on these counters (instead of the continuous
+    // timeEndLimit) makes them rebuild only on real changes, so hovering an
+    // item / objective / loot tooltip during playback no longer flickers.
+    const lootProgress = useMemo(() => {
+        if (!raidData?.looting) return 0
+        let n = 0
+        for (const l of raidData.looting) if (Number(l.time) <= timeEndLimit) n++
+        return n
+    }, [raidData?.looting, timeEndLimit])
+
+    const killProgress = useMemo(() => {
+        if (!raidData?.kills) return 0
+        let n = 0
+        for (const k of raidData.kills) if (Number(k.time) <= timeEndLimit) n++
+        return n
+    }, [raidData?.kills, timeEndLimit])
+
+    const objectiveProgress = useMemo(() => {
+        let n = 0
+        for (const o of botObjectiveData) if (Number(o.time) <= timeEndLimit) n++
+        return n
+    }, [botObjectiveData, timeEndLimit])
+
+    const questProgress = useMemo(() => {
+        let n = 0
+        for (const q of botQuestData) if (Number(q.time) <= timeEndLimit) n++
+        return n
+    }, [botQuestData, timeEndLimit])
+
+    const phobosSnapIdx = useMemo(() => {
+        let idx = -1
+        for (let i = 0; i < phobosFieldData.length; i++) {
+            if (phobosFieldData[i].time <= timeEndLimit) idx = i
+            else break
+        }
+        return idx
+    }, [phobosFieldData, timeEndLimit])
+
+    const orbitMainsProgress = useMemo(() => {
+        let n = 0
+        for (const e of orbitMainObjectivesData) if (Number(e.time) <= timeEndLimit) n++
+        return n
+    }, [orbitMainObjectivesData, timeEndLimit])
+
     // Loose Loot: render / update markers on map (timeline-aware + container grouping)
     useEffect(() => {
         if (!MAP || !mapIsReady) return
@@ -1686,7 +1816,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                 looseLootLayerRef.current = null
             }
         }
-    }, [MAP, mapIsReady, showLooseLoot, looseLootData, looseLootMinPrice, looseLootFilter, pickedUpItemIds, raidData?.looting, timeEndLimit])
+    }, [MAP, mapIsReady, showLooseLoot, looseLootData, looseLootMinPrice, looseLootFilter, raidData?.looting, lootProgress])
 
     // Bot Quests: always fetch data (panel visibility depends on data existing)
     useEffect(() => {
@@ -1803,7 +1933,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                 botQuestLayerRef.current = null
             }
         }
-    }, [MAP, mapIsReady, showBotQuests, botQuestData, timeEndLimit, raidData?.players, raidData?.kills, positions])
+    }, [MAP, mapIsReady, showBotQuests, botQuestData, questProgress, killProgress, raidData?.players, raidData?.kills, positions])
 
     // Bot Objectives (legacy Phobos / ORBIT): always fetch data (panel
     // visibility depends on data existing). Pulls from BOTH the legacy
@@ -1924,7 +2054,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                 botObjectiveLayerRef.current = null
             }
         }
-    }, [MAP, mapIsReady, showBotObjectives, botObjectiveData, timeEndLimit, raidData?.players, raidData?.kills, positions])
+    }, [MAP, mapIsReady, showBotObjectives, botObjectiveData, objectiveProgress, killProgress, raidData?.players, raidData?.kills, positions])
 
     // Phobos / ORBIT advection field: fetch snapshots once from both
     // sources and merge. Same shape, just two independent tables — drop
@@ -2063,7 +2193,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                 phobosFieldLayerRef.current = null
             }
         }
-    }, [MAP, mapIsReady, showPhobosField, showPhobosAdvection, showPhobosConvergence, showPhobosZones, phobosFieldData, timeEndLimit])
+    }, [MAP, mapIsReady, showPhobosField, showPhobosAdvection, showPhobosConvergence, showPhobosZones, phobosFieldData, phobosSnapIdx])
 
     // (Phobos POIs / squad-home / squad-main-force debug overlays were
     // removed — they served their purpose during integration validation
@@ -2205,7 +2335,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                 orbitMainObjectivesLayerRef.current = null
             }
         }
-    }, [MAP, mapIsReady, selectedSquadForMains, orbitMainObjectivesData, timeEndLimit, questNameMap])
+    }, [MAP, mapIsReady, selectedSquadForMains, orbitMainObjectivesData, orbitMainsProgress, questNameMap])
 
     // Loot float animations: show floating text when timeline crosses a loot event
     // Uses a ref-based approach to avoid useEffect cleanup killing the animation on re-render
@@ -2528,6 +2658,18 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
         
             // Skip layers managed by other overlays (quests, loose loot, grenades, etc.)
             if (layer._rr_quest || layer._rr_looseLoot || layer._rr_grenade || layer._rr_objective || layer._rr_phobos) continue;
+
+            // Persistent player-dot markers (issue #24) are mutated in place across
+            // frames, not torn down here; their lifecycle is reconciled in the main
+            // render effect. Other markers/polylines/circles still get cleared.
+            if (layer._rr_persistentPlayer) continue;
+
+            // Focus kill-visualization layers (kill/death lines, skull markers,
+            // dead-player temp marker) are now rebuilt only on focus/kill changes
+            // (gated by killVizSig), so clearMap must NOT strip them every frame —
+            // otherwise the skulls vanish mid-playback. The focus effect owns their
+            // teardown via focusLayersRef.
+            if (layer._rr_focusViz) continue;
 
             // Remove polylines without eventType or not being ballisticsLine, circles, and special bot markers
             const isSpecialBotMarker = layer instanceof L.Marker && layer.options?.icon?.options?.className === 'special-bot-marker';

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -2789,8 +2789,12 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
             if (classifyPlayer(player) === 'FACTION') {
                 const category = typeof player.type === 'string' && player.type.includes('|') ? player.type.split('|')[1] : ''
                 if (category === 'ISB') {
+                    const sainName = (player.mod_SAIN_name || '').trim()
                     const personality = (player.mod_SAIN_brain || '').trim()
                     const hasPersonality = personality !== '' && !['UNKNOWN', 'PMC', 'SCAV', 'PLAYER'].includes(personality)
+                    if (sainName !== '') {
+                        return hasPersonality ? `${sainName} - ${personality}` : sainName
+                    }
                     if (hasPersonality) brain = personality
                 } else {
                     const role = getFactionRole(player)

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -2782,10 +2782,20 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
         if (player) {
             let difficulty = player.mod_SAIN_difficulty
             let brain = getPlayerBrain(player)
-            // For faction-mod bots, show only their specific role (Rifleman, Grenadier, etc.)
+            // Faction-mod bots: show their specific role (Rifleman, Grenadier, etc.).
+            // ISB is the exception: its WildSpawnType names are misleading (variants
+            // reuse the boss-roster slot names), so for ISB show the SAIN
+            // "difficulty - personality" like regular bots instead of the role.
             if (classifyPlayer(player) === 'FACTION') {
-                const role = getFactionRole(player)
-                if (role) return role
+                const category = typeof player.type === 'string' && player.type.includes('|') ? player.type.split('|')[1] : ''
+                if (category === 'ISB') {
+                    const personality = (player.mod_SAIN_brain || '').trim()
+                    const hasPersonality = personality !== '' && !['UNKNOWN', 'PMC', 'SCAV', 'PLAYER'].includes(personality)
+                    if (hasPersonality) brain = personality
+                } else {
+                    const role = getFactionRole(player)
+                    if (role) return role
+                }
             }
             if (difficulty !== null && difficulty !== '') {
                 return `${difficulty} - ${brain}`

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -1546,6 +1546,12 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
             return
         }
 
+        // Frame-skip at high speeds. Keep a fixed ~24fps render cadence and advance
+        // `playbackSpeed` frames per tick, instead of shrinking the interval to
+        // 1000/(24*speed) — at 16x that asked for a 2.6ms interval the browser can't
+        // sustain (each tick is a full re-render), so the real speed capped at
+        // whatever the machine could render. Now 16x covers 16x the timeline per
+        // second at a constant render load.
         const interval = setInterval(() => {
             setTimeCurrentIndex((prevIndex) => {
                 // Check if we've reached the end of the sliderTimes
@@ -1555,8 +1561,9 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                     return prevIndex
                 }
 
-                const frame = sliderTimes[prevIndex]
-                const startFrame = sliderTimes[Math.max(0, prevIndex - dropOffIndex)]
+                const nextIndex = Math.min(prevIndex + playbackSpeed, sliderTimes.length - 1)
+                const frame = sliderTimes[nextIndex]
+                const startFrame = sliderTimes[Math.max(0, nextIndex - dropOffIndex)]
 
                 if (!preserveHistory && startFrame) {
                     setTimeStartLimit(startFrame)
@@ -1568,9 +1575,9 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
 
                 setTimeEndLimit(frame)
 
-                return prevIndex + 1
+                return nextIndex
             })
-        }, 1000 / (24 * playbackSpeed))
+        }, 1000 / 24)
 
         return () => clearInterval(interval)
     }, [playing, sliderTimes, playbackSpeed, timeCurrentIndex, preserveHistory])
@@ -3706,7 +3713,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                     <div className="text-eft mb-2 flex justify-between">
                         <span>{msToHMS(timeEndLimit)}</span>
                         <span className={`${hideNerdStats ? 'invisible' : ''}`}>
-                            {((timeCurrentIndex / sliderTimes.length) * 100).toFixed(0)}% | {24 * playbackSpeed}fps | Frame: {timeCurrentIndex} / {sliderTimes.length - 1} | Cut In/Out (ms): {timeStartLimit} / {timeEndLimit}
+                            {((timeCurrentIndex / sliderTimes.length) * 100).toFixed(0)}% | 24fps · {playbackSpeed}x | Frame: {timeCurrentIndex} / {sliderTimes.length - 1} | Cut In/Out (ms): {timeStartLimit} / {timeEndLimit}
                         </span>
                         <span>{msToHMS(sliderTimes.length > 0 ? sliderTimes[sliderTimes.length - 1] : 0)}</span>
                     </div>

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -66,7 +66,8 @@ function classifyPlayer(player: any): string {
         case 'MERCENARY':
         case 'RUAF':
         case 'UNTAR':
-        case 'BLACKDIV': return 'FACTION'
+        case 'BLACKDIV':
+        case 'ISB': return 'FACTION'
         case 'SCAV':
         default:
             if (player.type === 'PLAYER' && player.team === 'Savage') return 'SCAV'
@@ -2771,7 +2772,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
 
                                 // Faction sub-grouping by faction type
                                 if (group.key === 'FACTION') {
-                                    const FACTION_LABELS: Record<string, string> = { MERCENARY: 'Mercenary', RUAF: 'RUAF', UNTAR: 'UNTAR', BLACKDIV: 'Black Div' }
+                                    const FACTION_LABELS: Record<string, string> = { MERCENARY: 'Mercenary', RUAF: 'RUAF', UNTAR: 'UNTAR', BLACKDIV: 'Black Div', ISB: 'ISB' }
                                     const factions: Record<string, { player: any, originalIndex: number }[]> = {}
                                     items.forEach(item => {
                                         let fType = BotMapping[item.player.type]?.type

--- a/Private/src/helpers/players.tsx
+++ b/Private/src/helpers/players.tsx
@@ -35,6 +35,7 @@ export function getMarkerLabel(player: any): string | null {
     if (type.includes('RUAF')) return 'R'
     if (type.includes('UNTAR')) return 'U'
     if (type.includes('BLACK DIV')) return 'BD'
+    if (type.includes('ISB')) return 'IS'
 
     if (type.includes('SHADOW TAGILLA')) return 'ST'
     if (type.includes('VENGEFUL KILLA')) return 'VK'
@@ -96,6 +97,7 @@ export function getPlayerColor(player: any, index: number): string {
         case 'RUAF': return '#4A90D9'
         case 'UNTAR': return '#00BFFF'
         case 'BLACKDIV': return '#555555'
+        case 'ISB': return '#1ABC9C'
         case 'INFECTED': return '#7FFF00'
         default:
             if (player.type === 'PLAYER' && player.team === 'Savage') return '#33FF57'
@@ -126,7 +128,7 @@ export function getFactionRole(player: any): string {
     const typeName = ((player?.type || '') as string).split('|')[0]
     if (!typeName) return ''
     // Strip the known faction prefix (longest first so "BLACK DIV" matches before "BLACK")
-    const prefixes = ['BLACK DIV', 'RUAF', 'REMNANT', 'UNTAR', 'MERCENARY']
+    const prefixes = ['BLACK DIV', 'RUAF', 'REMNANT', 'UNTAR', 'MERCENARY', 'ISB']
     let role = typeName
     for (const p of prefixes) {
         if (typeName === p) { role = typeName; break }
@@ -173,6 +175,7 @@ export function getPlayerFaction(player: any): string {
         case 'RUAF': return 'RUAF'
         case 'UNTAR': return 'UNTAR'
         case 'BLACKDIV': return 'Black Div'
+        case 'ISB': return 'ISB'
         case 'INFECTED': return 'Infected'
         default: return 'Unknown'
     }

--- a/Private/src/pages/V2/RaidCharts.tsx
+++ b/Private/src/pages/V2/RaidCharts.tsx
@@ -56,6 +56,7 @@ const FACTION_COLORS: Record<string, string> = {
     'RUAF': '#4A90D9',
     'UNTAR': '#00BFFF',
     'Black Div': '#555555',
+    'ISB': '#1ABC9C',
     'Infected': '#7FFF00',
     'Other': '#00eeff',
     'Unknown': '#999',
@@ -77,7 +78,8 @@ function getFactionGroup(faction: string): string {
         case 'Mercenary':
         case 'RUAF':
         case 'UNTAR':
-        case 'Black Div': return 'Factions';
+        case 'Black Div':
+        case 'ISB': return 'Factions';
         case 'Infected': return 'Infected';
         default: return 'Other';
     }

--- a/Private/src/pages/V2/RaidOverview.tsx
+++ b/Private/src/pages/V2/RaidOverview.tsx
@@ -460,7 +460,11 @@ export default function RaidOverview() {
         return groupedBy.map((gp, groupIndex) => {
           const sorted = sortPlayers(gp);
           return sorted.map((p, index) => {
-            const SAIN = getPlayerDifficultyAndBrain(p).toLowerCase();
+            // No .toLowerCase() here: the `capitalize` CSS on the cell only upper-cases
+            // the first letter of each word, so lower-casing first would mangle all-caps
+            // labels like "ISB" into "Isb". The map legend doesn't lower-case either, so
+            // this keeps the two views consistent.
+            const SAIN = getPlayerDifficultyAndBrain(p);
             const isMainPlayer = p.profileId === raid.profileId;
             const lastSample = lastSampleByProfile.get(p.profileId) ?? 0;
             const lastStatus = lastStatusByProfile.get(p.profileId) ?? '';

--- a/Private/src/pages/V2/RaidOverview.tsx
+++ b/Private/src/pages/V2/RaidOverview.tsx
@@ -29,6 +29,7 @@ const FACTION_COLORS: Record<string, { color: string, label: string }> = {
     'RUAF':        { color: '#4A90D9', label: 'RUAF' },
     'UNTAR':       { color: '#00BFFF', label: 'UNTAR' },
     'BLACK DIV':   { color: '#555555', label: 'Black Div' },
+    'ISB':         { color: '#1ABC9C', label: 'ISB' },
     'SNIPER':      { color: '#00911a', label: 'Sniper' },
     'PLAYER SCAV': { color: '#33FF8D', label: 'P. Scav' },
     'INFECTED':    { color: '#7FFF00', label: 'Infected' },
@@ -209,7 +210,7 @@ export default function RaidOverview() {
         }
 
         if (groupedByType === 'TEAM') {
-          const SIDE_ORDER = ['Player', 'USEC', 'BEAR', 'P. Scav', 'Boss', 'Goon', 'Follower', 'Raider', 'Rogue', 'Cultist', 'Bloodhound', 'Special', 'Infected', 'Mercenary', 'RUAF', 'UNTAR', 'Black Div', 'Sniper', 'Scav'];
+          const SIDE_ORDER = ['Player', 'USEC', 'BEAR', 'P. Scav', 'Boss', 'Goon', 'Follower', 'Raider', 'Rogue', 'Cultist', 'Bloodhound', 'Special', 'Infected', 'Mercenary', 'RUAF', 'UNTAR', 'Black Div', 'ISB', 'Sniper', 'Scav'];
           const grouped = _.groupBy(raid.players, p => {
             if (p.profileId === raid.profileId) return 'Player';
             const isPMC = p.team === 'Usec' || p.team === 'Bear';
@@ -336,6 +337,8 @@ export default function RaidOverview() {
                   return "UNTAR"
               case 'BLACKDIV':
                   return "BLACK DIV"
+              case 'ISB':
+                  return "ISB"
               case 'INFECTED':
                   return "INFECTED"
               case 'SPECIAL':
@@ -359,7 +362,7 @@ export default function RaidOverview() {
 
           // Faction-mod bots: show only their specific role (Rifleman, Grenadier, etc.)
           const category = typeof player.type === "string" && player.type.includes("|") ? player.type.split("|")[1] : "";
-          if (["RUAF", "UNTAR", "BLACKDIV", "MERCENARY"].includes(category)) {
+          if (["RUAF", "UNTAR", "BLACKDIV", "MERCENARY", "ISB"].includes(category)) {
             const role = getFactionRole(player);
             if (role) return role;
           }

--- a/Private/src/pages/V2/RaidOverview.tsx
+++ b/Private/src/pages/V2/RaidOverview.tsx
@@ -360,11 +360,21 @@ export default function RaidOverview() {
           let difficulty = player.mod_SAIN_difficulty;
           let brain = getPlayerBrain(player);
 
-          // Faction-mod bots: show only their specific role (Rifleman, Grenadier, etc.)
+          // Faction-mod bots (RUAF, UNTAR, BLACKDIV, MERCENARY): show their specific
+          // role (Rifleman, Grenadier, etc.).
           const category = typeof player.type === "string" && player.type.includes("|") ? player.type.split("|")[1] : "";
-          if (["RUAF", "UNTAR", "BLACKDIV", "MERCENARY", "ISB"].includes(category)) {
+          if (["RUAF", "UNTAR", "BLACKDIV", "MERCENARY"].includes(category)) {
             const role = getFactionRole(player);
             if (role) return role;
+          }
+
+          // ISB only: its WildSpawnType names are misleading (variants reuse the
+          // boss-roster slot names), so show the SAIN "difficulty - personality" like
+          // regular bots instead of the role.
+          if (category === "ISB") {
+            const personality = (player.mod_SAIN_brain || "").trim();
+            const hasPersonality = personality !== "" && !["UNKNOWN", "PMC", "SCAV", "PLAYER"].includes(personality);
+            if (hasPersonality) brain = personality;
           }
 
           if (difficulty !== null && difficulty !== "") {

--- a/Private/src/pages/V2/RaidOverview.tsx
+++ b/Private/src/pages/V2/RaidOverview.tsx
@@ -369,11 +369,16 @@ export default function RaidOverview() {
           }
 
           // ISB only: its WildSpawnType names are misleading (variants reuse the
-          // boss-roster slot names), so show the SAIN "difficulty - personality" like
-          // regular bots instead of the role.
+          // boss-roster slot names). Prefer SAIN's author-controlled bot-type name
+          // (e.g. "ISB Operator"), appending the SAIN personality when known; if no
+          // SAIN name was captured, fall back to the "difficulty - personality" string.
           if (category === "ISB") {
+            const sainName = (player.mod_SAIN_name || "").trim();
             const personality = (player.mod_SAIN_brain || "").trim();
             const hasPersonality = personality !== "" && !["UNKNOWN", "PMC", "SCAV", "PLAYER"].includes(personality);
+            if (sainName !== "") {
+              return hasPersonality ? `${sainName} - ${personality}` : sainName;
+            }
             if (hasPersonality) brain = personality;
           }
 

--- a/Private/src/types/api_types.d.ts
+++ b/Private/src/types/api_types.d.ts
@@ -55,6 +55,7 @@ export interface TrackingRaidDataPlayers {
   spawnTime: number
   mod_SAIN_brain: string
   mod_SAIN_difficulty: string
+  mod_SAIN_name: string
 }
 
 export interface TrackingRaidDataKills {

--- a/ServerMod/Database/DatabaseService.cs
+++ b/ServerMod/Database/DatabaseService.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading.Channels;
 using Microsoft.Data.Sqlite;
 
 namespace RaidReview.Database;
@@ -9,6 +10,17 @@ public class DatabaseService : IDisposable
     private SqliteConnection? _connection;
     private string _dbPath = string.Empty;
     private static IntPtr _nativeSqliteHandle;
+    private Action<string>? _log;
+
+    // Write-behind queue for high-rate single-row inserts (BALLISTIC during firefights, PLAYER_STATUS).
+    // Producers enqueue and return immediately; one drain task coalesces ~250ms windows into a single
+    // transaction per statement shape, collapsing dozens of per-row commits into one. Order within a
+    // table is preserved (single reader). Bounded staleness: rows are visible at most ~250ms late,
+    // which nothing reads that fast mid-raid.
+    private readonly Channel<(string sql, (string name, object? value)[] parameters)> _writeBehind =
+        Channel.CreateUnbounded<(string, (string, object?)[])>(new UnboundedChannelOptions { SingleReader = true });
+    private Task? _writeBehindDrainTask;
+    private readonly CancellationTokenSource _writeBehindCts = new();
 
     public async Task InitializeAsync(string dataFolder, Action<string>? log = null)
     {
@@ -99,6 +111,50 @@ public class DatabaseService : IDisposable
         await ExecuteOnAsync(_connection, "PRAGMA temp_store = MEMORY;");
 
         await RunMigrationsAsync();
+
+        _log = log;
+        _writeBehindDrainTask = Task.Run(() => DrainWriteBehindAsync(_writeBehindCts.Token));
+    }
+
+    /// <summary>
+    /// Fire-and-forget insert for high-rate event streams. The statement lands within ~250ms,
+    /// batched with everything else queued in that window. Use ExecuteAsync when the caller
+    /// needs the row visible immediately (raid lifecycle, dedup-sensitive writes).
+    /// </summary>
+    public void QueueWrite(string sql, params (string name, object? value)[] parameters)
+        => _writeBehind.Writer.TryWrite((sql, parameters));
+
+    private async Task DrainWriteBehindAsync(CancellationToken ct)
+    {
+        var pending = new List<(string sql, (string name, object? value)[] parameters)>(256);
+        while (true)
+        {
+            try
+            {
+                if (!await _writeBehind.Reader.WaitToReadAsync(ct)) return;
+                // Coalesce the burst: grab what's there, give the window a moment to fill, grab again.
+                while (_writeBehind.Reader.TryRead(out var item)) pending.Add(item);
+                await Task.Delay(250, ct);
+                while (_writeBehind.Reader.TryRead(out var item)) pending.Add(item);
+
+                foreach (var group in pending.GroupBy(p => p.sql))
+                    await ExecuteBatchAsync(group.Key, group.Select(g => g.parameters));
+                pending.Clear();
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutdown: push whatever is still queued before letting go.
+                while (_writeBehind.Reader.TryRead(out var item)) pending.Add(item);
+                foreach (var group in pending.GroupBy(p => p.sql))
+                    try { await ExecuteBatchAsync(group.Key, group.Select(g => g.parameters)); } catch { /* best effort on shutdown */ }
+                return;
+            }
+            catch (Exception ex)
+            {
+                _log?.Invoke($"[DB] write-behind drain error ({pending.Count} rows dropped): {ex.Message}");
+                pending.Clear();
+            }
+        }
     }
 
     private string _connectionString = string.Empty;
@@ -449,6 +505,26 @@ public class DatabaseService : IDisposable
                     FOREIGN KEY (""raidId"") REFERENCES raid(""raidId"")
                 );
             "),
+            // Every UI / API read filters on raidId, but only raid + loose_loot were indexed — the
+            // raid-detail endpoints full-scanned every table, slower with each raid the GC keeps.
+            // The player dedup (raidId, profileId) is UNIQUE so the PLAYER packet handler can use a
+            // bare INSERT OR IGNORE instead of its per-spawn SELECT round-trip; the DELETE clears any
+            // duplicate rows that slipped in before this index existed (concurrent PLAYER packets).
+            ("add_raid_id_indexes", @"
+                DELETE FROM player WHERE rowid NOT IN (SELECT MIN(rowid) FROM player GROUP BY raidId, profileId);
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_player_raid_profile ON player(""raidId"", ""profileId"");
+                CREATE INDEX IF NOT EXISTS idx_kills_raidId ON kills(""raidId"");
+                CREATE INDEX IF NOT EXISTS idx_looting_raidId ON looting(""raidId"");
+                CREATE INDEX IF NOT EXISTS idx_ballistic_raidId ON ballistic(""raidId"");
+                CREATE INDEX IF NOT EXISTS idx_player_status_raidId ON player_status(""raidId"");
+                CREATE INDEX IF NOT EXISTS idx_player_inventory_raidId ON player_inventory(""raidId"");
+                CREATE INDEX IF NOT EXISTS idx_bot_quest_raidId ON bot_quest(""raidId"");
+                CREATE INDEX IF NOT EXISTS idx_bot_objective_raidId ON bot_objective(""raidId"");
+                CREATE INDEX IF NOT EXISTS idx_phobos_field_raidId ON phobos_field(""raidId"");
+                CREATE INDEX IF NOT EXISTS idx_orbit_field_raidId ON orbit_field(""raidId"");
+                CREATE INDEX IF NOT EXISTS idx_orbit_bot_objective_raidId ON orbit_bot_objective(""raidId"");
+                CREATE INDEX IF NOT EXISTS idx_orbit_main_objectives_raidId ON orbit_main_objectives(""raidId"");
+            "),
         };
 
         foreach (var (name, sql) in migrations)
@@ -551,6 +627,10 @@ public class DatabaseService : IDisposable
 
     public void Dispose()
     {
+        // Stop the write-behind drain and give it a moment to flush what's queued.
+        _writeBehindCts.Cancel();
+        try { _writeBehindDrainTask?.Wait(TimeSpan.FromSeconds(3)); }
+        catch (AggregateException) { }
         _connection?.Dispose();
     }
 }

--- a/ServerMod/Database/DatabaseService.cs
+++ b/ServerMod/Database/DatabaseService.cs
@@ -525,6 +525,9 @@ public class DatabaseService : IDisposable
                 CREATE INDEX IF NOT EXISTS idx_orbit_bot_objective_raidId ON orbit_bot_objective(""raidId"");
                 CREATE INDEX IF NOT EXISTS idx_orbit_main_objectives_raidId ON orbit_main_objectives(""raidId"");
             "),
+            ("add_mod_sain_name", @"
+                ALTER TABLE player ADD COLUMN ""mod_SAIN_name"" TEXT NOT NULL DEFAULT '';
+            "),
         };
 
         foreach (var (name, sql) in migrations)

--- a/ServerMod/Database/DatabaseService.cs
+++ b/ServerMod/Database/DatabaseService.cs
@@ -73,10 +73,41 @@ public class DatabaseService : IDisposable
         Directory.CreateDirectory(dataFolder);
         _dbPath = Path.Combine(dataFolder, "raid_review_mod.db");
 
-        _connection = new SqliteConnection($"Data Source={_dbPath}");
+        // Connection string with pooling so per-call connections in
+        // ExecuteAsync / QueryAsync get reused from the pool instead of
+        // re-opening the file each time. Cache=Shared lets the same
+        // in-memory page cache be shared across pooled connections.
+        _connectionString = $"Data Source={_dbPath};Pooling=True;Cache=Shared";
+        _connection = new SqliteConnection(_connectionString);
         await _connection.OpenAsync();
 
+        // WAL mode allows one writer + many concurrent readers without
+        // blocking on the same write lock. busy_timeout makes any caller
+        // wait up to 5s for the lock instead of erroring instantly, which
+        // is what was starving the Kestrel thread pool: every concurrent
+        // ws packet handler was serialising through the single shared
+        // connection's exclusive write lock.
+        await ExecuteOnAsync(_connection, "PRAGMA journal_mode = WAL;");
+        await ExecuteOnAsync(_connection, "PRAGMA busy_timeout = 5000;");
+        await ExecuteOnAsync(_connection, "PRAGMA synchronous = NORMAL;");
+        // temp_store = MEMORY keeps SQLite's transient indexes, sort scratch and intermediate result sets
+        // off the physical disk and in process RAM. Reported as a meaningful speedup on slow / write-through
+        // RAID arrays (Krelsis.net, Discord) where every disk write is a synchronous round-trip — moving
+        // the throwaway temp data out of that path takes a significant chunk of small writes off the I/O
+        // queue. Costs a small amount of RAM (typically a few hundred KB) and zero risk: the data is
+        // by definition temporary and doesn't survive a transaction commit.
+        await ExecuteOnAsync(_connection, "PRAGMA temp_store = MEMORY;");
+
         await RunMigrationsAsync();
+    }
+
+    private string _connectionString = string.Empty;
+
+    private static async Task ExecuteOnAsync(SqliteConnection conn, string sql)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
     }
 
     public SqliteConnection Connection => _connection ?? throw new InvalidOperationException("Database not initialized.");
@@ -451,16 +482,51 @@ public class DatabaseService : IDisposable
 
     public async Task ExecuteAsync(string sql, params (string name, object? value)[] parameters)
     {
-        using var cmd = _connection!.CreateCommand();
+        // Per-call connection from the pool: previously every WS packet
+        // handler was contending on the single shared _connection, which
+        // serialised every DB write behind SQLite's exclusive write lock
+        // and starved the Kestrel thread pool. With pooling + WAL mode
+        // each handler grabs its own connection, runs its statement, and
+        // releases — the pool reuses opened handles so it's cheap.
+        using var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync();
+        using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
         foreach (var (name, value) in parameters)
             cmd.Parameters.AddWithValue(name, value ?? DBNull.Value);
         await cmd.ExecuteNonQueryAsync();
     }
 
+    /// <summary>
+    /// Bulk INSERT helper: wraps N executions in a single transaction so
+    /// the per-row fsync cost collapses into one. Used by LOOSE_LOOT
+    /// which can land hundreds of items per packet — without batching,
+    /// each INSERT acquires the write lock + fsyncs the journal, killing
+    /// the thread pool under load.
+    /// </summary>
+    public async Task ExecuteBatchAsync(string sql, IEnumerable<(string name, object? value)[]> parameterSets)
+    {
+        using var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync();
+        using var tx = (SqliteTransaction)await conn.BeginTransactionAsync();
+        using var cmd = conn.CreateCommand();
+        cmd.Transaction = tx;
+        cmd.CommandText = sql;
+        foreach (var paramSet in parameterSets)
+        {
+            cmd.Parameters.Clear();
+            foreach (var (name, value) in paramSet)
+                cmd.Parameters.AddWithValue(name, value ?? DBNull.Value);
+            await cmd.ExecuteNonQueryAsync();
+        }
+        await tx.CommitAsync();
+    }
+
     public async Task<List<Dictionary<string, object?>>> QueryAsync(string sql, params (string name, object? value)[] parameters)
     {
-        using var cmd = _connection!.CreateCommand();
+        using var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync();
+        using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
         foreach (var (name, value) in parameters)
             cmd.Parameters.AddWithValue(name, value ?? DBNull.Value);

--- a/ServerMod/FileSystem/DataFileService.cs
+++ b/ServerMod/FileSystem/DataFileService.cs
@@ -9,16 +9,28 @@ public class DataFileService
     // Avoid hammering the disk on every WS POSITION packet (one per
     // player per tick — 80-300/s in a busy raid). Directory.CreateDirectory
     // and File.Exists checks are sync syscalls that were starving the
-    // Kestrel thread pool. We remember dirs we've ensured and files
-    // we've already written headers for so the hot path skips them.
+    // Kestrel thread pool. We remember dirs we've ensured; appended files
+    // get a persistent buffered writer (see _appenders below).
     private readonly ConcurrentDictionary<string, byte> _ensuredDirs = new();
-    private readonly ConcurrentDictionary<string, byte> _headerWritten = new();
+
+    // Persistent buffered writers for the append hot path. File.AppendAllText
+    // opens + flushes + closes the file PER LINE — at position-stream rates
+    // that's hundreds of full open/close cycles per second, which is exactly
+    // what hurts on write-through arrays (Krelsis report). A StreamWriter per
+    // file turns those into in-memory buffer writes; a 1s timer flushes so
+    // live readers (UI mid-raid) stay at most a second behind. FlushAndCloseAll
+    // runs at raid END before post-processing reads the file.
+    private readonly ConcurrentDictionary<string, StreamWriter> _appenders = new();
+    private readonly object _appenderLock = new();
+    private Timer? _flushTimer;
 
     public void Initialize(string dataFolder)
     {
         _dataFolder = dataFolder;
         _ensuredDirs.Clear();
-        _headerWritten.Clear();
+        FlushAndCloseAll();
+        _flushTimer?.Dispose();
+        _flushTimer = new Timer(_ => FlushAll(), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
     }
 
     private string BuildPath(string parentFolder, string subFolder, string targetFolder, string fileName)
@@ -36,41 +48,56 @@ public class DataFileService
     }
 
     /// <summary>
-    /// Hot-path append used by the WebSocket POSITION dispatch. Async so
-    /// the I/O wait doesn't block the Kestrel thread pool, plus dir and
-    /// header existence are cached to avoid the per-call FS syscalls.
+    /// Hot-path append used by the WebSocket POSITION dispatch. Writes go to the file's persistent
+    /// buffered writer (created on first call; header emitted iff the file is new/empty), so the
+    /// per-line cost is a memory copy. The flush timer publishes to disk every second.
     /// </summary>
-    public async Task WriteLineToFileAsync(string parentFolder, string subFolder, string targetFolder, string fileName, string keys, string value)
+    public void AppendLineBuffered(string parentFolder, string subFolder, string targetFolder, string fileName, string keys, string value)
     {
         var path = BuildPath(parentFolder, subFolder, targetFolder, fileName);
-        EnsureDirectory(Path.GetDirectoryName(path)!);
-
-        // First write to this path: emit the header (the keys line) then
-        // the value. Subsequent writes skip the existence check entirely.
-        if (_headerWritten.TryAdd(path, 0))
+        var writer = _appenders.GetOrAdd(path, p =>
         {
-            // The path might already exist from a previous server run
-            // (raid resumed, etc.) — in that case we'd duplicate the
-            // header. Cheaper to accept that edge than to spam File.Exists.
-            if (!File.Exists(path))
-            {
-                await File.AppendAllTextAsync(path, keys);
-            }
+            EnsureDirectory(Path.GetDirectoryName(p)!);
+            // FileShare.Read so the web server can read the (flushed) file while the raid is live.
+            var stream = new FileStream(p, FileMode.Append, FileAccess.Write, FileShare.Read);
+            var w = new StreamWriter(stream);
+            if (stream.Length == 0)
+                w.Write(keys);
+            return w;
+        });
+        // StreamWriter isn't thread-safe and WS handlers can run concurrently. One lock for all
+        // appenders is plenty at these rates — the critical section is a buffer memcpy.
+        lock (_appenderLock)
+        {
+            writer.Write(value);
         }
-
-        await File.AppendAllTextAsync(path, value);
     }
 
-    /// <summary>Legacy sync variant kept for non-hot callers.</summary>
-    public void WriteLineToFile(string parentFolder, string subFolder, string targetFolder, string fileName, string keys, string value)
+    public void FlushAll()
     {
-        var path = BuildPath(parentFolder, subFolder, targetFolder, fileName);
-        EnsureDirectory(Path.GetDirectoryName(path)!);
+        lock (_appenderLock)
+        {
+            foreach (var writer in _appenders.Values)
+            {
+                try { writer.Flush(); }
+                catch (ObjectDisposedException) { }
+            }
+        }
+    }
 
-        if (!File.Exists(path))
-            File.WriteAllText(path, keys);
-
-        File.AppendAllText(path, value);
+    /// <summary>Flush + close every buffered appender. Called at raid END before post-processing
+    /// reads the position files, and on re-initialize.</summary>
+    public void FlushAndCloseAll()
+    {
+        lock (_appenderLock)
+        {
+            foreach (var kv in _appenders)
+            {
+                try { kv.Value.Dispose(); }
+                catch (ObjectDisposedException) { }
+            }
+            _appenders.Clear();
+        }
     }
 
     public string? ReadFile(string parentFolder, string subFolder, string targetFolder, string fileName)
@@ -88,9 +115,17 @@ public class DataFileService
     public void DeleteFile(string parentFolder, string subFolder, string targetFolder, string fileName)
     {
         var path = BuildPath(parentFolder, subFolder, targetFolder, fileName);
+        // Close the appender first or the open write handle blocks the delete.
+        if (_appenders.TryRemove(path, out var writer))
+        {
+            lock (_appenderLock)
+            {
+                try { writer.Dispose(); }
+                catch (ObjectDisposedException) { }
+            }
+        }
         if (File.Exists(path))
             File.Delete(path);
-        _headerWritten.TryRemove(path, out _);
     }
 
     public List<string> ReadFolderContents(string parentFolder, string subFolder, string targetFolder)

--- a/ServerMod/FileSystem/DataFileService.cs
+++ b/ServerMod/FileSystem/DataFileService.cs
@@ -1,12 +1,24 @@
+using System.Collections.Concurrent;
+
 namespace RaidReview.FileSystem;
 
 public class DataFileService
 {
     private string _dataFolder = string.Empty;
 
+    // Avoid hammering the disk on every WS POSITION packet (one per
+    // player per tick — 80-300/s in a busy raid). Directory.CreateDirectory
+    // and File.Exists checks are sync syscalls that were starving the
+    // Kestrel thread pool. We remember dirs we've ensured and files
+    // we've already written headers for so the hot path skips them.
+    private readonly ConcurrentDictionary<string, byte> _ensuredDirs = new();
+    private readonly ConcurrentDictionary<string, byte> _headerWritten = new();
+
     public void Initialize(string dataFolder)
     {
         _dataFolder = dataFolder;
+        _ensuredDirs.Clear();
+        _headerWritten.Clear();
     }
 
     private string BuildPath(string parentFolder, string subFolder, string targetFolder, string fileName)
@@ -19,16 +31,41 @@ public class DataFileService
     public void WriteFile(string parentFolder, string subFolder, string targetFolder, string fileName, string content)
     {
         var path = BuildPath(parentFolder, subFolder, targetFolder, fileName);
-        var dir = Path.GetDirectoryName(path)!;
-        Directory.CreateDirectory(dir);
+        EnsureDirectory(Path.GetDirectoryName(path)!);
         File.WriteAllText(path, content);
     }
 
+    /// <summary>
+    /// Hot-path append used by the WebSocket POSITION dispatch. Async so
+    /// the I/O wait doesn't block the Kestrel thread pool, plus dir and
+    /// header existence are cached to avoid the per-call FS syscalls.
+    /// </summary>
+    public async Task WriteLineToFileAsync(string parentFolder, string subFolder, string targetFolder, string fileName, string keys, string value)
+    {
+        var path = BuildPath(parentFolder, subFolder, targetFolder, fileName);
+        EnsureDirectory(Path.GetDirectoryName(path)!);
+
+        // First write to this path: emit the header (the keys line) then
+        // the value. Subsequent writes skip the existence check entirely.
+        if (_headerWritten.TryAdd(path, 0))
+        {
+            // The path might already exist from a previous server run
+            // (raid resumed, etc.) — in that case we'd duplicate the
+            // header. Cheaper to accept that edge than to spam File.Exists.
+            if (!File.Exists(path))
+            {
+                await File.AppendAllTextAsync(path, keys);
+            }
+        }
+
+        await File.AppendAllTextAsync(path, value);
+    }
+
+    /// <summary>Legacy sync variant kept for non-hot callers.</summary>
     public void WriteLineToFile(string parentFolder, string subFolder, string targetFolder, string fileName, string keys, string value)
     {
         var path = BuildPath(parentFolder, subFolder, targetFolder, fileName);
-        var dir = Path.GetDirectoryName(path)!;
-        Directory.CreateDirectory(dir);
+        EnsureDirectory(Path.GetDirectoryName(path)!);
 
         if (!File.Exists(path))
             File.WriteAllText(path, keys);
@@ -53,6 +90,7 @@ public class DataFileService
         var path = BuildPath(parentFolder, subFolder, targetFolder, fileName);
         if (File.Exists(path))
             File.Delete(path);
+        _headerWritten.TryRemove(path, out _);
     }
 
     public List<string> ReadFolderContents(string parentFolder, string subFolder, string targetFolder)
@@ -60,5 +98,13 @@ public class DataFileService
         var dir = BuildPath(parentFolder, subFolder, targetFolder, "");
         if (!Directory.Exists(dir)) return new List<string>();
         return Directory.GetFiles(dir).Select(Path.GetFileName).Where(f => f != null).Cast<string>().ToList();
+    }
+
+    private void EnsureDirectory(string dir)
+    {
+        if (string.IsNullOrEmpty(dir)) return;
+        if (_ensuredDirs.ContainsKey(dir)) return;
+        Directory.CreateDirectory(dir);
+        _ensuredDirs.TryAdd(dir, 0);
     }
 }

--- a/ServerMod/ModMetadata.cs
+++ b/ServerMod/ModMetadata.cs
@@ -8,7 +8,7 @@ public record ModMetadata : AbstractModMetadata
     public override string Name { get; init; } = "Raid Review";
     public override string Author { get; init; } = "Ekky";
     public override List<string>? Contributors { get; init; } = ["Chazu"];
-    public override SemanticVersioning.Version Version { get; init; } = new("1.1.0");
+    public override SemanticVersioning.Version Version { get; init; } = new("1.2.0");
     public override SemanticVersioning.Range SptVersion { get; init; } = new("~4.0.0");
     public override List<string>? Incompatibilities { get; init; }
     public override Dictionary<string, SemanticVersioning.Range>? ModDependencies { get; init; }

--- a/ServerMod/ServerMod.csproj
+++ b/ServerMod/ServerMod.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
     <OutputPath>bin\$(Configuration)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <!-- Copy NuGet runtime deps to output folder -->

--- a/ServerMod/WebSocket/WsPacketHandler.cs
+++ b/ServerMod/WebSocket/WsPacketHandler.cs
@@ -169,9 +169,10 @@ public class WsPacketHandler
                 case "PLAYER_UPDATE":
                 {
                     await _db.ExecuteAsync(
-                        "UPDATE player SET mod_SAIN_brain = $brain, mod_SAIN_difficulty = $diff, type = $type WHERE raidId = $raidId AND profileId = $profileId",
+                        "UPDATE player SET mod_SAIN_brain = $brain, mod_SAIN_difficulty = $diff, mod_SAIN_name = $sainName, type = $type WHERE raidId = $raidId AND profileId = $profileId",
                         ("$brain", GetString(payload, "mod_SAIN_brain")),
                         ("$diff", GetString(payload, "mod_SAIN_difficulty")),
+                        ("$sainName", GetString(payload, "mod_SAIN_name")),
                         ("$type", GetString(payload, "type")),
                         ("$raidId", raidId!),
                         ("$profileId", GetString(payload, "profileId")));
@@ -195,7 +196,7 @@ public class WsPacketHandler
                     // Dedup rides on the UNIQUE (raidId, profileId) index — the old SELECT round-trip
                     // full-scanned the player table once per bot spawn (spawn waves = burst of scans).
                     await _db.ExecuteAsync(
-                        @"INSERT OR IGNORE INTO player (raidId, profileId, level, team, name, ""group"", spawnTime, type, mod_SAIN_brain, mod_SAIN_difficulty) VALUES ($raidId, $profileId, $level, $team, $name, $group, $spawnTime, $type, $brain, $diff)",
+                        @"INSERT OR IGNORE INTO player (raidId, profileId, level, team, name, ""group"", spawnTime, type, mod_SAIN_brain, mod_SAIN_difficulty, mod_SAIN_name) VALUES ($raidId, $profileId, $level, $team, $name, $group, $spawnTime, $type, $brain, $diff, $sainName)",
                         ("$raidId", raidId!),
                         ("$profileId", profileId),
                         ("$level", GetString(payload, "level")),
@@ -205,7 +206,8 @@ public class WsPacketHandler
                         ("$spawnTime", GetString(payload, "spawnTime")),
                         ("$type", GetString(payload, "type")),
                         ("$brain", GetString(payload, "mod_SAIN_brain")),
-                        ("$diff", GetString(payload, "mod_SAIN_difficulty")));
+                        ("$diff", GetString(payload, "mod_SAIN_difficulty")),
+                        ("$sainName", GetString(payload, "mod_SAIN_name")));
                     break;
                 }
 
@@ -459,7 +461,7 @@ public class WsPacketHandler
         if (exists.Count > 0) return;
 
         await _db.ExecuteAsync(
-            @"INSERT INTO player (raidId, profileId, level, team, name, ""group"", spawnTime, mod_SAIN_brain, type, mod_SAIN_difficulty) VALUES ($raidId, $profileId, $level, $team, $name, $group, $spawnTime, $brain, $type, $diff)",
+            @"INSERT INTO player (raidId, profileId, level, team, name, ""group"", spawnTime, mod_SAIN_brain, type, mod_SAIN_difficulty, mod_SAIN_name) VALUES ($raidId, $profileId, $level, $team, $name, $group, $spawnTime, $brain, $type, $diff, $sainName)",
             ("$raidId", raidId),
             ("$profileId", profileId),
             ("$level", GetString(playerEl, "level")),
@@ -469,7 +471,8 @@ public class WsPacketHandler
             ("$spawnTime", GetString(playerEl, "spawnTime")),
             ("$brain", GetString(playerEl, "mod_SAIN_brain")),
             ("$type", GetString(playerEl, "type")),
-            ("$diff", GetString(playerEl, "mod_SAIN_difficulty")));
+            ("$diff", GetString(playerEl, "mod_SAIN_difficulty")),
+            ("$sainName", GetString(playerEl, "mod_SAIN_name")));
     }
 
     private static string GetString(JsonElement el, string key)

--- a/ServerMod/WebSocket/WsPacketHandler.cs
+++ b/ServerMod/WebSocket/WsPacketHandler.cs
@@ -147,6 +147,9 @@ public class WsPacketHandler
 
                     _sessionManager.RemoveRaid(raidId!, "Received 'onGameSessionEnd' packet from Raid-Review client mod.");
 
+                    // Publish the buffered position stream before post-processing reads the CSV.
+                    _fileService.FlushAndCloseAll();
+
                     _startPostProcessing?.Invoke(raidId!);
                     _logger.Log("Enabled Post Processing: Raid Finished");
                     break;
@@ -177,7 +180,7 @@ public class WsPacketHandler
 
                 case "PLAYER_STATUS":
                 {
-                    await _db.ExecuteAsync(
+                    _db.QueueWrite(
                         "INSERT INTO player_status (raidId, profileId, time, status) VALUES ($raidId, $profileId, $time, $status)",
                         ("$raidId", raidId!),
                         ("$profileId", GetString(payload, "profileId")),
@@ -189,14 +192,10 @@ public class WsPacketHandler
                 case "PLAYER":
                 {
                     var profileId = GetString(payload, "profileId");
-                    var exists = await _db.QueryAsync(
-                        "SELECT * FROM player WHERE raidId = $raidId AND profileId = $profileId",
-                        ("$raidId", raidId!), ("$profileId", profileId));
-
-                    if (exists.Count > 0) break;
-
+                    // Dedup rides on the UNIQUE (raidId, profileId) index — the old SELECT round-trip
+                    // full-scanned the player table once per bot spawn (spawn waves = burst of scans).
                     await _db.ExecuteAsync(
-                        @"INSERT INTO player (raidId, profileId, level, team, name, ""group"", spawnTime, type, mod_SAIN_brain, mod_SAIN_difficulty) VALUES ($raidId, $profileId, $level, $team, $name, $group, $spawnTime, $type, $brain, $diff)",
+                        @"INSERT OR IGNORE INTO player (raidId, profileId, level, team, name, ""group"", spawnTime, type, mod_SAIN_brain, mod_SAIN_difficulty) VALUES ($raidId, $profileId, $level, $team, $name, $group, $spawnTime, $type, $brain, $diff)",
                         ("$raidId", raidId!),
                         ("$profileId", profileId),
                         ("$level", GetString(payload, "level")),
@@ -212,7 +211,9 @@ public class WsPacketHandler
 
                 case "BALLISTIC":
                 {
-                    await _db.ExecuteAsync(
+                    // Highest-rate DB stream in the mod (one row per round fired during firefights) —
+                    // write-behind coalesces the burst into one transaction per ~250ms window.
+                    _db.QueueWrite(
                         "INSERT INTO ballistic (raidId, time, profileId, weaponId, weaponName, ammoId, hitPlayerId, source, target) VALUES ($raidId, $time, $profileId, $weaponId, $weaponName, $ammoId, $hitPlayerId, $source, $target)",
                         ("$raidId", raidId!),
                         ("$time", GetString(payload, "time")),
@@ -248,7 +249,7 @@ public class WsPacketHandler
                     var filename = $"{raidId}_positions";
                     var keys = ExtractKeysLine(payload);
                     var values = ExtractValuesLine(payload);
-                    await _fileService.WriteLineToFileAsync("positions", "", "", filename, keys + "\n", values + "\n");
+                    _fileService.AppendLineBuffered("positions", "", "", filename, keys + "\n", values + "\n");
                     break;
                 }
 

--- a/ServerMod/WebSocket/WsPacketHandler.cs
+++ b/ServerMod/WebSocket/WsPacketHandler.cs
@@ -248,7 +248,7 @@ public class WsPacketHandler
                     var filename = $"{raidId}_positions";
                     var keys = ExtractKeysLine(payload);
                     var values = ExtractValuesLine(payload);
-                    _fileService.WriteLineToFile("positions", "", "", filename, keys + "\n", values + "\n");
+                    await _fileService.WriteLineToFileAsync("positions", "", "", filename, keys + "\n", values + "\n");
                     break;
                 }
 
@@ -276,11 +276,15 @@ public class WsPacketHandler
                     if (raidId == null) break;
                     if (payload.TryGetProperty("items", out var itemsArr) && itemsArr.ValueKind == JsonValueKind.Array)
                     {
+                        // Batch all inserts into one transaction — a raid
+                        // can ship hundreds of loose loot items in a
+                        // single packet and one-fsync-per-insert was a
+                        // major write-lock contention source.
+                        var batch = new List<(string name, object? value)[]>();
                         foreach (var item in itemsArr.EnumerateArray())
                         {
-                            await _db.ExecuteAsync(
-                                @"INSERT OR IGNORE INTO loose_loot (raidId, itemId, templateId, itemName, price, qty, x, y, z, inContainer, containerName)
-                                  VALUES ($raidId, $itemId, $templateId, $itemName, $price, $qty, $x, $y, $z, $inContainer, $containerName)",
+                            batch.Add(new (string name, object? value)[]
+                            {
                                 ("$raidId", raidId!),
                                 ("$itemId", GetString(item, "itemId")),
                                 ("$templateId", GetString(item, "templateId")),
@@ -291,7 +295,15 @@ public class WsPacketHandler
                                 ("$y", GetString(item, "y")),
                                 ("$z", GetString(item, "z")),
                                 ("$inContainer", item.TryGetProperty("inContainer", out var ic) && ic.GetBoolean() ? "1" : "0"),
-                                ("$containerName", GetString(item, "containerName")));
+                                ("$containerName", GetString(item, "containerName")),
+                            });
+                        }
+                        if (batch.Count > 0)
+                        {
+                            await _db.ExecuteBatchAsync(
+                                @"INSERT OR IGNORE INTO loose_loot (raidId, itemId, templateId, itemName, price, qty, x, y, z, inContainer, containerName)
+                                  VALUES ($raidId, $itemId, $templateId, $itemName, $price, $qty, $x, $y, $z, $inContainer, $containerName)",
+                                batch);
                         }
                     }
                     break;


### PR DESCRIPTION
Write-path performance pass, map replay fixes (issue #24 + the 16x speed report), and ISB faction support.

## Changes

### Performance — data write path

**SQLite + filesystem pass (`7cc5994`)** — reported by Krelsis (Discord): heavy stutter on a write-through RAID array, every WS packet serialising behind the single shared SQLite write lock and the position stream hammering sync syscalls on the Kestrel thread pool.
- WAL journal mode, `busy_timeout` 5s, `synchronous = NORMAL`, `temp_store = MEMORY`.
- Connection pooling (`Pooling=True;Cache=Shared`); `ExecuteAsync`/`QueryAsync` use per-call pooled connections instead of contending on one shared connection.
- `ExecuteBatchAsync` collapses N statements into one transaction (LOOSE_LOOT inserts batched).
- Position stream + ensured-dir / header-written caches drop per-call `Directory.CreateDirectory` / `File.Exists` syscalls.

**Write-path pass 2 (`040875f`)** — the three remaining hotspots:
- **Buffered position stream:** persistent `StreamWriter` per file (`FileShare.Read` so the UI can read mid-raid); writes are memory copies, a 1s timer publishes to disk, raid-end flushes + closes before post-processing reads. `DeleteFile` closes the appender first.
- **raidId indexes** on every per-raid table (kills / looting / ballistic / player / player_status / player_inventory / bot_* / phobos_field / orbit_*); `UNIQUE (raidId, profileId)` on player after a one-time duplicate sweep, letting the PLAYER handler drop its per-spawn SELECT dedup for `INSERT OR IGNORE`.
- **Write-behind queue** for BALLISTIC (one row per round fired) + PLAYER_STATUS: enqueue and return immediately, a single drain task coalesces ~250ms windows into one transaction per statement shape (order preserved, rows ≤250ms late, Dispose flushes).

### Map replay — `Private/src/component/MapComponent.tsx`

**Tooltip flicker + name jitter (issue #24, `51b9a4c`):**
- Player dots are now persistent and mutated in place (`setLatLng` / icon / tooltip) across frames instead of being torn down by `clearMap` and rebuilt by `createPlayerMarker` every tick. Lifecycle (death / scrub-out) reconciled in the render effect; markers live in `markerPane` (above per-frame polylines) and are exempt from `clearMap`.
- Follow-pan uses `panTo(endOfLine, { animate: false })` instead of the bare `4`, which took Leaflet's animated branch and restarted a 0.25s tween every frame (the ~1px name wobble).
- Focus-overlay tooltip is only re-applied / reopened when its content changes, reverted on focus change — no per-frame close/open.
- Overlay effects (loose loot, bot objectives, bot quests, Phobos field, ORBIT main objectives) are keyed on discrete timeline-progress counters instead of the continuous `timeEndLimit`, so their tooltip'd markers rebuild only when an event crosses the playhead.
- Focus kill-visualisation (kill/death lines, skull markers, dead-player temp marker) is gated on a focus + kill-set signature and tagged `_rr_focusViz` so `clearMap` no longer strips it every frame.

**Speed multipliers (`b37b334`):** the playback loop shrank its interval to `1000/(24*playbackSpeed)` and advanced one frame per tick, so 16x asked for a 2.6ms interval the browser can't sustain (each tick is a full re-render) and capped at whatever the machine could render. It now runs at a fixed ~24fps cadence and advances `playbackSpeed` frames per tick, so 16x covers 16x the timeline per second at constant render load.

### Faction

**ISB faction (`dd3083c`):** ISB bots fell through to the generic faction default and showed up as "Follower". Added a dedicated faction (mirroring UNTAR / RUAF / BLACKDIV): client `MapWildSpawnType` + SAIN `getBotType` cases, `botMapping.json` entries, and frontend colour (#1ABC9C) / marker (IS) / `ISB` prefix across charts, overview and map.

### Misc

**ORBIT probe log (`5a39d19`):** `InitReflection` runs every tick; the "API ready" probe now logs once per raid (latched, reset on raid teardown) instead of flooding the BepInEx log.