### PR TITLE
Feature/1.4.0

### DIFF
--- a/Client/RAID-REVIEW.csproj
+++ b/Client/RAID-REVIEW.csproj
@@ -7,7 +7,7 @@
 		<AssemblyDescription>A post raid review tool for SPT</AssemblyDescription>
 		<AssemblyCompany>EkkyLLC</AssemblyCompany>
 		<AssemblyProduct>RAID_REVIEW</AssemblyProduct>
-		<AssemblyVersion>1.3.0</AssemblyVersion>
+		<AssemblyVersion>1.4.0</AssemblyVersion>
 		<Copyright>2024 © Ekky</Copyright>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<OutputPath>C:\Games\SPT-4.0-hardcore\BepInEx\plugins\</OutputPath>

--- a/Client/integrations/Integrations.cs
+++ b/Client/integrations/Integrations.cs
@@ -24,15 +24,24 @@ namespace RAID_REVIEW {
                 // usability — users without these mods can flip them off).
                 if (RAID_REVIEW.DetectMod("com.danw.questingbots"))
                 {
-                    if (RAID_REVIEW.EnableLegacyQuestingBots != null && RAID_REVIEW.EnableLegacyQuestingBots.Value)
+                    // QB >= 0.11.0 ships an official interop surface (QuestingBotsExternal) — the
+                    // supported path, always enabled. Older versions fall back to the legacy
+                    // reflection integration, still gated by its F12 toggle.
+                    if (QuestingBotsInterop.Init())
                     {
-                        LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: Found 'QuestingBots' — legacy integration enabled. NO SUPPORT — uses reflection. Disable in F12 if you see errors.");
+                        LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: Found 'QuestingBots' — official interop available (QB >= 0.11.0), enabling integration.");
+                        RAID_REVIEW.DANW_QUESTINGBOTS__DETECTED = true;
+                        RAID_REVIEW.RAID_REVIEW__DETECTED_MODS.Add("QUESTING_BOTS");
+                    }
+                    else if (RAID_REVIEW.EnableLegacyQuestingBots != null && RAID_REVIEW.EnableLegacyQuestingBots.Value)
+                    {
+                        LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: Found 'QuestingBots' (pre-0.11) — legacy integration enabled. NO SUPPORT — uses reflection. Disable in F12 if you see errors.");
                         RAID_REVIEW.DANW_QUESTINGBOTS__DETECTED = true;
                         RAID_REVIEW.RAID_REVIEW__DETECTED_MODS.Add("QUESTING_BOTS");
                     }
                     else
                     {
-                        LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: Found 'QuestingBots' — legacy integration disabled by user toggle.");
+                        LoggerInstance.Log.LogInfo("RAID_REVIEW :::: INFO :::: Found 'QuestingBots' (pre-0.11) — legacy integration disabled by user toggle.");
                     }
                 }
                 if (RAID_REVIEW.DetectMod("com.janky.phobos"))

--- a/Client/integrations/QuestingBots.cs
+++ b/Client/integrations/QuestingBots.cs
@@ -38,6 +38,15 @@ namespace RAID_REVIEW
             if (_reflectionInit) return;
             _reflectionInit = true;
 
+            // QB >= 0.11.0 ships an official interop surface (QuestingBotsExternal) — prefer it and
+            // skip the unsupported legacy reflection entirely.
+            if (QuestingBotsInterop.Init())
+            {
+                _available = true;
+                LoggerInstance.Log.LogInfo("RAID_REVIEW :::: QUESTINGBOTS :::: Official interop detected (QB >= 0.11.0) — legacy reflection skipped");
+                return;
+            }
+
             try
             {
                 // BotJobAssignmentFactory has extension methods on BotOwner
@@ -113,6 +122,50 @@ namespace RAID_REVIEW
             {
                 var botOwner = player.AIData?.BotOwner;
                 if (botOwner == null) return null;
+
+                // Official interop path (QB >= 0.11.0).
+                if (QuestingBotsInterop.Init())
+                {
+                    var info = QuestingBotsInterop.GetBotQuestInfo(botOwner);
+                    if (info == null || !info.IsValid) return null;
+
+                    // No active quest: emit a single quiet "None" record so the timeline closes the
+                    // previous quest, without churning on decision/action changes.
+                    if (!info.HasAQuest)
+                    {
+                        return new TrackingBotQuest
+                        {
+                            sessionId = sessionId,
+                            profileId = player.ProfileId,
+                            time = time,
+                            questName = "",
+                            isEFTQuest = false,
+                            actionType = "",
+                            status = "None",
+                            objectiveX = 0,
+                            objectiveY = 0,
+                            objectiveZ = 0
+                        };
+                    }
+
+                    // The official surface exposes no assignment-status string; HasAQuest implies an
+                    // active (Pending/Active) assignment, which is what the decision override keys on.
+                    var loc = info.QuestLocation;
+                    var hasLoc = !float.IsNegativeInfinity(loc.x);
+                    return new TrackingBotQuest
+                    {
+                        sessionId = sessionId,
+                        profileId = player.ProfileId,
+                        time = time,
+                        questName = info.QuestName,
+                        isEFTQuest = info.IsEftQuest,
+                        actionType = info.CurrentActionType,
+                        status = "Active",
+                        objectiveX = hasLoc ? loc.x : 0,
+                        objectiveY = hasLoc ? loc.y : 0,
+                        objectiveZ = hasLoc ? loc.z : 0
+                    };
+                }
 
                 // Call GetCurrentJobAssignment(botOwner, false) — false = don't trigger reassignment
                 object assignment;

--- a/Client/integrations/QuestingBotsInterop.cs
+++ b/Client/integrations/QuestingBotsInterop.cs
@@ -1,0 +1,186 @@
+using BepInEx.Bootstrap;
+using EFT;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace RAID_REVIEW
+{
+    // Official QuestingBots interop consumer, adapted from the upstream example
+    // (SPTQuestingBots/Interop/Client-InteropTest/QuestingBotsInterop.cs). Talks to
+    // QuestingBots.QuestingBotsExternal (shipped since QB 0.11.0) via cached reflection.
+    // Older QB versions don't have the External class — Init() returns false and the
+    // legacy reflection integration in QuestingBots.cs takes over.
+
+    internal class QuestingBotsBotQuestInfo
+    {
+        public bool IsValid { get; private set; } = false;
+        public string CurrentDecision { get; private set; } = string.Empty;
+        public string CurrentActionType { get; private set; } = string.Empty;
+        public string QuestName { get; private set; } = string.Empty;
+        public Vector3 QuestLocation { get; private set; } = Vector3.negativeInfinity;
+        public bool IsEftQuest { get; private set; } = false;
+
+        public bool HasAQuest => QuestName != string.Empty;
+
+        public QuestingBotsBotQuestInfo() { }
+
+        public QuestingBotsBotQuestInfo(string currentDecision, string currentActionType) : this()
+        {
+            CurrentDecision = currentDecision;
+            CurrentActionType = currentActionType;
+            IsValid = true;
+        }
+
+        public QuestingBotsBotQuestInfo(string currentDecision, string currentActionType, string questName, Vector3 questLocation, bool isEftQuest) : this(currentDecision, currentActionType)
+        {
+            QuestName = questName;
+            QuestLocation = questLocation;
+            IsEftQuest = isEftQuest;
+        }
+    }
+
+    internal class QuestingBotsBotJobAssignmentHistoryEntry
+    {
+        public bool IsValid { get; private set; } = false;
+        public string StartTimestampText { get; private set; } = string.Empty;
+        public string EndTimestampText { get; private set; } = string.Empty;
+        public string QuestName { get; private set; } = string.Empty;
+        public string QuestObjectiveName { get; private set; } = string.Empty;
+        public string QuestStep { get; private set; } = string.Empty;
+        public string Status { get; private set; } = string.Empty;
+
+        public long StartTimestamp => long.Parse(StartTimestampText);
+        public long EndTimestamp => long.Parse(EndTimestampText);
+
+        public QuestingBotsBotJobAssignmentHistoryEntry() { }
+
+        public QuestingBotsBotJobAssignmentHistoryEntry(string startTimestamp, string endTimestamp, string questName, string questObjectiveName, string questStep, string status) : this()
+        {
+            StartTimestampText = startTimestamp;
+            EndTimestampText = endTimestamp;
+            QuestName = questName;
+            QuestObjectiveName = questObjectiveName;
+            QuestStep = questStep;
+            Status = status;
+            IsValid = true;
+        }
+    }
+
+    internal static class QuestingBotsInterop
+    {
+        private static bool _QuestingBotsLoadedChecked = false;
+        private static bool _QuestingBotsInteropInited = false;
+
+        private static bool _IsQuestingBotsLoaded;
+        private static Type _QuestingBotsExternalType = null;
+
+        private static MethodInfo _GetCurrentDecisionMethod = null;
+        private static MethodInfo _GetCurrentQuestActionTypeMethod = null;
+        private static MethodInfo _GetCurrentQuestNameMethod = null;
+        private static MethodInfo _GetCurrentQuestLocationMethod = null;
+        private static MethodInfo _IsCurrentJobAssignmentAnEftQuestMethod = null;
+        private static MethodInfo _IsCurrentJobAssignmentActiveMethod = null;
+        private static MethodInfo _HasAQuestingBossMethod = null;
+        private static MethodInfo _GetJobAssignmentHistoryCsvDataMethod = null;
+
+        public static bool IsQuestingBotsLoaded()
+        {
+            // Only check for Questing Bots once
+            if (!_QuestingBotsLoadedChecked)
+            {
+                _QuestingBotsLoadedChecked = true;
+                _IsQuestingBotsLoaded = Chainloader.PluginInfos.ContainsKey("com.danw.questingbots");
+            }
+
+            return _IsQuestingBotsLoaded;
+        }
+
+        /// <summary>
+        /// Initialize the interop class data. Returns true when the External class exists (QB >= 0.11.0).
+        /// </summary>
+        public static bool Init()
+        {
+            if (!IsQuestingBotsLoaded()) return false;
+
+            // Only check for the External class once
+            if (!_QuestingBotsInteropInited)
+            {
+                _QuestingBotsInteropInited = true;
+
+                _QuestingBotsExternalType = Type.GetType("QuestingBots.QuestingBotsExternal, QuestingBots-Client");
+
+                if (_QuestingBotsExternalType != null)
+                {
+                    _GetCurrentDecisionMethod = AccessTools.Method(_QuestingBotsExternalType, "GetCurrentDecision");
+                    _GetCurrentQuestActionTypeMethod = AccessTools.Method(_QuestingBotsExternalType, "GetCurrentQuestActionType");
+                    _GetCurrentQuestNameMethod = AccessTools.Method(_QuestingBotsExternalType, "GetCurrentQuestName");
+                    _GetCurrentQuestLocationMethod = AccessTools.Method(_QuestingBotsExternalType, "GetCurrentQuestLocation");
+                    _IsCurrentJobAssignmentAnEftQuestMethod = AccessTools.Method(_QuestingBotsExternalType, "IsCurrentJobAssignmentAnEftQuest");
+                    _IsCurrentJobAssignmentActiveMethod = AccessTools.Method(_QuestingBotsExternalType, "HasActiveJobAssignment");
+                    _HasAQuestingBossMethod = AccessTools.Method(_QuestingBotsExternalType, "HasAQuestingBoss");
+                    _GetJobAssignmentHistoryCsvDataMethod = AccessTools.Method(_QuestingBotsExternalType, "GetJobAssignmentHistoryCsvData");
+                }
+            }
+
+            return (_QuestingBotsExternalType != null);
+        }
+
+        /// <summary>
+        /// All current questing information for the specified bot.
+        /// </summary>
+        public static QuestingBotsBotQuestInfo GetBotQuestInfo(BotOwner bot)
+        {
+            if (!Init()) return new QuestingBotsBotQuestInfo();
+            if (_GetCurrentDecisionMethod == null) return new QuestingBotsBotQuestInfo();
+            if (_GetCurrentQuestActionTypeMethod == null) return new QuestingBotsBotQuestInfo();
+            if (_GetCurrentQuestNameMethod == null) return new QuestingBotsBotQuestInfo();
+            if (_GetCurrentQuestLocationMethod == null) return new QuestingBotsBotQuestInfo();
+            if (_IsCurrentJobAssignmentAnEftQuestMethod == null) return new QuestingBotsBotQuestInfo();
+            if (_IsCurrentJobAssignmentActiveMethod == null) return new QuestingBotsBotQuestInfo();
+            if (_HasAQuestingBossMethod == null) return new QuestingBotsBotQuestInfo();
+
+            string decision = (string)_GetCurrentDecisionMethod.Invoke(null, new object[] { bot });
+            string actionType = (string)_GetCurrentQuestActionTypeMethod.Invoke(null, new object[] { bot });
+
+            bool hasActiveJob = (bool)_IsCurrentJobAssignmentActiveMethod.Invoke(null, new object[] { bot });
+            bool hasAQuestingBoss = (bool)_HasAQuestingBossMethod.Invoke(null, new object[] { bot });
+            if (!hasActiveJob || hasAQuestingBoss)
+            {
+                return new QuestingBotsBotQuestInfo(decision, actionType);
+            }
+
+            string questName = (string)_GetCurrentQuestNameMethod.Invoke(null, new object[] { bot });
+            Vector3 questLocation = (Vector3)_GetCurrentQuestLocationMethod.Invoke(null, new object[] { bot });
+            bool isEftQuest = (bool)_IsCurrentJobAssignmentAnEftQuestMethod.Invoke(null, new object[] { bot });
+
+            return new QuestingBotsBotQuestInfo(decision, actionType, questName, questLocation, isEftQuest);
+        }
+
+        /// <summary>
+        /// Information about all job assignments for the specified bot (unused for now — kept in
+        /// sync with the upstream interop example for future timeline work).
+        /// </summary>
+        public static IEnumerable<QuestingBotsBotJobAssignmentHistoryEntry> GetJobAssignmentHistory(BotOwner bot)
+        {
+            if (!Init()) yield break;
+            if (_GetJobAssignmentHistoryCsvDataMethod == null) yield break;
+
+            IEnumerable<string[]> historyCsvEntries = (IEnumerable<string[]>)_GetJobAssignmentHistoryCsvDataMethod.Invoke(null, new object[] { bot });
+            foreach (string[] historyCsvEntry in historyCsvEntries)
+            {
+                yield return new QuestingBotsBotJobAssignmentHistoryEntry
+                (
+                    historyCsvEntry[0],
+                    historyCsvEntry[1],
+                    historyCsvEntry[2],
+                    historyCsvEntry[3],
+                    historyCsvEntry[4],
+                    historyCsvEntry[5]
+                );
+            }
+        }
+    }
+}

--- a/Client/integrations/SAIN.cs
+++ b/Client/integrations/SAIN.cs
@@ -127,7 +127,11 @@ namespace RAID_REVIEW
                                     // but mod.cs already identified them correctly via player.Profile.Info.Settings.Role.
                                     bool currentIsGeneric = trackingPlayer.type == "BOT" || trackingPlayer.type == "UNKNOWN" || trackingPlayer.type == "SCAV|SCAV";
                                     bool sainIsGeneric = sainType == "SCAV|SCAV" || sainType == "SCAV GROUP|SCAV" || sainType == "CRAZY SCAV EVENT|SCAV" || sainType == "TAGGED AND CURSED SCAV|SCAV";
-                                    if (currentIsGeneric || !sainIsGeneric)
+                                    // Never clobber the hunt override: SAIN only sees the raw pmcBot role
+                                    // ("RAIDER|FOLLOWER") for MoreBotsAPI hunt squads, mod.cs already
+                                    // identified them via their spawn id.
+                                    bool currentIsHuntOverride = trackingPlayer.type == "UNTAR HUNTER|UNTAR";
+                                    if ((currentIsGeneric || !sainIsGeneric) && !currentIsHuntOverride)
                                     {
                                         trackingPlayer.type = sainType;
                                     }
@@ -446,6 +450,11 @@ namespace RAID_REVIEW
                             break;
                         case "ISBFireflyShielder02":
                             RR_WildSpawnType = "ISB FIREFLY SHIELDER 2|ISB";
+                            break;
+                        // ISB 1.0 "White Tusk" commander duo — display name per Firefly.
+                        case "ISBBossCommander":
+                        case "ISBFollowerCommander":
+                            RR_WildSpawnType = "WHITE TUSK|ISB";
                             break;
 
                         // Manimal's Combine Soldiers (keep in sync with MapWildSpawnType in mod.cs)

--- a/Client/integrations/SAIN.cs
+++ b/Client/integrations/SAIN.cs
@@ -457,6 +457,14 @@ namespace RAID_REVIEW
                             RR_WildSpawnType = "WHITE TUSK|ISB";
                             break;
 
+                        // Wedge boss mod (keep in sync with MapWildSpawnType in mod.cs)
+                        case "wedge":
+                            RR_WildSpawnType = "WEDGE|BOSS";
+                            break;
+                        case "wedgeguard":
+                            RR_WildSpawnType = "WEDGE GUARD|FOLLOWER";
+                            break;
+
                         // Manimal's Combine Soldiers (keep in sync with MapWildSpawnType in mod.cs)
                         case "CombineSoldier":
                             RR_WildSpawnType = "COMBINE SOLDIER|COMBINE";

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -189,6 +189,9 @@ namespace RAID_REVIEW
                 // ISB 1.0 "White Tusk" commander duo (enum values 13707/13708) — display name per Firefly.
                 case "ISBBossCommander": return "WHITE TUSK|ISB";
                 case "ISBFollowerCommander": return "WHITE TUSK|ISB";
+                // Wedge boss mod (prepatch pins wedge=848430 / wedgeguard=848431 into the enum)
+                case "wedge": return "WEDGE|BOSS";
+                case "wedgeguard": return "WEDGE GUARD|FOLLOWER";
                 // Manimal's Combine Soldiers
                 case "CombineSoldier": return "COMBINE SOLDIER|COMBINE";
                 case "CombineShotgunner": return "COMBINE SHOTGUNNER|COMBINE";

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -994,8 +994,12 @@ namespace RAID_REVIEW
                                             if (_seenLayerNames.Add(layerName))
                                                 Logger.LogInfo($"RAID_REVIEW :::: BRAIN_LAYER :::: {layerName}");
 
-                                            // BigBrain layer names from various mods
-                                            if (layerName.Contains("Loot"))
+                                            // BigBrain layer names from various mods. "LootPatrol" is a
+                                            // vanilla BSG layer — only credit LootingBots for other
+                                            // Loot* layers, and only when the mod is actually loaded.
+                                            if (layerName == "LootPatrol")
+                                                decision = layerName;
+                                            else if (layerName.Contains("Loot") && RAID_REVIEW__DETECTED_MODS.Contains("LOOTING_BOTS"))
                                                 decision = "LootingBots:" + layerName;
                                             else if (layerName.Contains("Follower") || layerName.Contains("Regroup"))
                                                 decision = "BL:" + layerName;

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -23,7 +23,7 @@ using EFT.Interactive;
 
 namespace RAID_REVIEW
 {
-    [BepInPlugin("ekky.raidreview", "Raid Review", "1.3.0")]
+    [BepInPlugin("ekky.raidreview", "Raid Review", "1.4.0")]
     [BepInDependency("me.sol.sain", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("com.danw.questingbots", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("com.janky.phobos", BepInDependency.DependencyFlags.SoftDependency)]

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -688,7 +688,7 @@ namespace RAID_REVIEW
             EnableLegacyPhobos = Config.Bind<bool>("Legacy Integrations", "Enable legacy Phobos integration", true,
                 "Captures bot-objective data from the legacy upstream Phobos mod (com.janky.phobos). NO SUPPORT — uses reflection (the mod doesn't expose a public API). Disable if you see errors.");
             EnableLegacyQuestingBots = Config.Bind<bool>("Legacy Integrations", "Enable legacy QuestingBots integration", true,
-                "Captures quest data from the QuestingBots mod (com.danw.questingbots). NO SUPPORT — uses reflection. Disable if you see errors.");
+                "Only used with QuestingBots older than 0.11.0 (newer versions use the official interop API, always enabled). NO SUPPORT — uses reflection. Disable if you see errors.");
 
             // HTTP/Websocket Endpoint Builders
             RAID_REVIEW_WS_Server = (ServerTLS.Value ? "wss://" : "ws://") + ServerAddress.Value + (ServerWsPort.Value != "" ? ":" + ServerWsPort.Value : "");

--- a/Client/mod.cs
+++ b/Client/mod.cs
@@ -74,6 +74,25 @@ namespace RAID_REVIEW
         public static GameObject Hook;
 
         /// <summary>
+        /// MoreBotsAPI "hunt" squads (e.g. UNTAR Go Home raider hunts on Woods/Customs) spawn as plain
+        /// pmcBot with no custom role, so role mapping alone shows them as vanilla Raiders. The API's own
+        /// discriminator is the spawn id: SpawnParams.Id_spawn contains "hunt" (see MoreBotsAPI
+        /// HuntManager.OnBotCreated). Same check here.
+        /// </summary>
+        public static bool IsHuntSpawn(Player player)
+        {
+            try
+            {
+                var idSpawn = player?.AIData?.BotOwner?.SpawnProfileData?.SpawnParams?.Id_spawn;
+                return idSpawn != null && idSpawn.ToLower().Contains("hunt");
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Maps a WildSpawnType to a Raid Review display string ("NAME|CATEGORY").
         /// Used as a fallback when SAIN is not installed.
         /// </summary>
@@ -167,6 +186,9 @@ namespace RAID_REVIEW
                 case "ISBFireflyFollowerVipper": return "ISB FIREFLY VIPPER|ISB";
                 case "ISBFireflyShielder01": return "ISB FIREFLY SHIELDER 1|ISB";
                 case "ISBFireflyShielder02": return "ISB FIREFLY SHIELDER 2|ISB";
+                // ISB 1.0 "White Tusk" commander duo (enum values 13707/13708) — display name per Firefly.
+                case "ISBBossCommander": return "WHITE TUSK|ISB";
+                case "ISBFollowerCommander": return "WHITE TUSK|ISB";
                 // Manimal's Combine Soldiers
                 case "CombineSoldier": return "COMBINE SOLDIER|COMBINE";
                 case "CombineShotgunner": return "COMBINE SHOTGUNNER|COMBINE";
@@ -834,6 +856,10 @@ namespace RAID_REVIEW
                                 {
                                     var role = player.Profile.Info.Settings.Role;
                                     trackingPlayer.type = MapWildSpawnType(role);
+                                    // UNTAR Go Home raider hunts: plain pmcBot spawned by MoreBotsAPI's
+                                    // hunt system — label as UNTAR hunter instead of a vanilla Raider.
+                                    if (role.ToString() == "pmcBot" && IsHuntSpawn(player))
+                                        trackingPlayer.type = "UNTAR HUNTER|UNTAR";
                                     // Override cyrillic names for known bosses
                                     if (role.ToString() == "bossPartisan") trackingPlayer.name = "Partizan";
                                 }

--- a/Private/src/assets/botMapping.json
+++ b/Private/src/assets/botMapping.json
@@ -135,6 +135,14 @@
         "name": "Kaban Sniper",
         "type": "FOLLOWER"
     },
+    "WEDGE|BOSS": {
+        "name": "Wedge",
+        "type": "BOSS"
+    },
+    "WEDGE GUARD|FOLLOWER": {
+        "name": "Wedge Guard",
+        "type": "FOLLOWER"
+    },
     "KOLONTAY|BOSS": {
         "name": "Kolontay",
         "type": "BOSS"

--- a/Private/src/assets/botMapping.json
+++ b/Private/src/assets/botMapping.json
@@ -243,6 +243,10 @@
         "name": "UNTAR Officer",
         "type": "UNTAR"
     },
+    "UNTAR HUNTER|UNTAR": {
+        "name": "UNTAR Hunter",
+        "type": "UNTAR"
+    },
     "BLACK DIV LEAD|BLACKDIV": {
         "name": "Black Div Lead",
         "type": "BLACKDIV"
@@ -289,6 +293,10 @@
     },
     "ISB FIREFLY SHIELDER 2|ISB": {
         "name": "ISB Firefly Shielder 2",
+        "type": "ISB"
+    },
+    "WHITE TUSK|ISB": {
+        "name": "White Tusk",
         "type": "ISB"
     },
     "COMBINE SOLDIER|COMBINE": {

--- a/Private/src/component/MapComponent.tsx
+++ b/Private/src/component/MapComponent.tsx
@@ -3276,7 +3276,7 @@ export default function MapComponent({ raidData, raidId, positions, intl_dir }) 
                                                     }
                                                 }
                                                 return Object.entries(latestByBot)
-                                                    .filter(([profileId, q]) => q.status !== 'Completed' && q.status !== 'Archived' && q.status !== 'Failed' && !deadOrGone.has(profileId))
+                                                    .filter(([profileId, q]) => q.questName && q.status !== 'None' && q.status !== 'Completed' && q.status !== 'Archived' && q.status !== 'Failed' && !deadOrGone.has(profileId))
                                                     .map(([profileId, q]) => {
                                                         const player = raidData?.players?.find(p => p.profileId === profileId)
                                                         const botName = player?.name || profileId.slice(0, 8)

--- a/Private/src/helpers/players.tsx
+++ b/Private/src/helpers/players.tsx
@@ -26,6 +26,7 @@ export function getMarkerLabel(player: any): string | null {
     if (type.includes('KABAN')) return 'Kb'
     if (type.includes('KOLONTAY')) return 'Ko'
     if (type.includes('PARTIZAN')) return 'P'
+    if (type.includes('WEDGE')) return 'We'
 
     if (type.includes('KNIGHT')) return 'Kn'
     if (type.includes('BIGPIPE')) return 'BP'

--- a/ServerMod/ModMetadata.cs
+++ b/ServerMod/ModMetadata.cs
@@ -8,7 +8,7 @@ public record ModMetadata : AbstractModMetadata
     public override string Name { get; init; } = "Raid Review";
     public override string Author { get; init; } = "Ekky";
     public override List<string>? Contributors { get; init; } = ["Chazu"];
-    public override SemanticVersioning.Version Version { get; init; } = new("1.3.0");
+    public override SemanticVersioning.Version Version { get; init; } = new("1.4.0");
     public override SemanticVersioning.Range SptVersion { get; init; } = new("~4.0.0");
     public override List<string>? Incompatibilities { get; init; }
     public override Dictionary<string, SemanticVersioning.Range>? ModDependencies { get; init; }

--- a/ServerMod/ServerMod.csproj
+++ b/ServerMod/ServerMod.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <OutputPath>bin\$(Configuration)\$(AssemblyName)\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <!-- Copy NuGet runtime deps to output folder -->


### PR DESCRIPTION
# Raid Review 1.4.0

## QuestingBots integration, now official

Questing Bots 0.11.0 added a proper API for other mods, and Raid Review now uses it. If you run QB, your raid replays show what each bot was doing:

- Quest names in the behavior tooltips
- Quest objectives on the map
- A **Bot Quests** panel listing who is working on what (EFT quests and QB custom quests)

No setup needed, it just works when both mods are installed. Older QB versions still use the previous integration.

## New bot labels

- UNTAR hunters are now labeled **UNTAR Hunter** instead of Raider
- ISB **White Tusk** commanders are properly named
- **Wedge** (boss mod) shows as a boss with his guards, with map markers